### PR TITLE
Revert "Bluefin - Moved Open Position And Add Liquidity to Legacy Sui"

### DIFF
--- a/src/apps/bluefin/helper.ts
+++ b/src/apps/bluefin/helper.ts
@@ -1,43 +1,49 @@
 import { TransactionType } from '@msafe/sui3-utils';
-import { SuiClient } from '@mysten/sui.js/client';
-import { TransactionBlock } from '@mysten/sui.js/transactions';
-import { SuiSignTransactionBlockInput, WalletAccount } from '@mysten/wallet-standard';
+import { SuiClient } from '@mysten/sui/client';
+import { Transaction } from '@mysten/sui/transactions';
+import { IdentifierString, WalletAccount } from '@mysten/wallet-standard';
 
-import { IAppHelperInternalLegacy } from '@/apps/interface/sui-js';
+import { IAppHelperInternal } from '@/apps/interface/sui';
 
 import { Decoder } from './decoder';
-// import { ClosePosition } from './intentions/close-position';
-// import { CollectFee } from './intentions/collect-fee';
-// import { CollectFeeAndRewards } from './intentions/collect-fee-and-rewards';
-// import { CollectRewards } from './intentions/collect-rewards';
+import { ClosePosition } from './intentions/close-position';
+import { CollectFee } from './intentions/collect-fee';
+import { CollectFeeAndRewards } from './intentions/collect-fee-and-rewards';
+import { CollectRewards } from './intentions/collect-rewards';
 import { OpenAndAddLiquidity } from './intentions/open-position-with-liquidity';
-// import { ProvideLiquidity } from './intentions/provide-liquidity';
-// import { RemoveLiquidity } from './intentions/remove-liquidity';
+import { ProvideLiquidity } from './intentions/provide-liquidity';
+import { RemoveLiquidity } from './intentions/remove-liquidity';
 import { SuiNetworks, BluefinIntentionData, TransactionSubType } from './types';
 
-export type BluefinIntention = OpenAndAddLiquidity;
-// | ProvideLiquidity
-// | RemoveLiquidity
-// | ClosePosition
-// | CollectFee
-// | CollectRewards
-// | CollectFeeAndRewards;
-export class BluefinHelper implements IAppHelperInternalLegacy<BluefinIntentionData> {
+export type BluefinIntention =
+  | OpenAndAddLiquidity
+  | ProvideLiquidity
+  | RemoveLiquidity
+  | ClosePosition
+  | CollectFee
+  | CollectRewards
+  | CollectFeeAndRewards;
+export class BluefinHelper implements IAppHelperInternal<BluefinIntentionData> {
   application = 'bluefin';
 
-  supportSDK = '@mysten/sui.js' as const;
+  supportSDK = '@mysten/sui' as const;
 
-  async deserialize(
-    input: SuiSignTransactionBlockInput & { network: SuiNetworks; suiClient: SuiClient; account: WalletAccount },
-  ): Promise<{
-    txType: TransactionType;
-    txSubType: TransactionSubType;
-    intentionData: BluefinIntentionData;
-  }> {
+  async deserialize(input: {
+    transaction: Transaction;
+    chain: IdentifierString;
+    network: SuiNetworks;
+    suiClient: SuiClient;
+    account: WalletAccount;
+    action?: string;
+    txbParams?: any;
+  }): Promise<{ txType: TransactionType; txSubType: string; intentionData: BluefinIntentionData }> {
     console.log('Bluefin helper deserialize input: ', input);
-    const { transactionBlock } = input;
-    const decoder = new Decoder(transactionBlock);
+    const { transaction } = input;
+
+    const decoder = new Decoder(transaction);
+
     const result = decoder.decode();
+
     return {
       txType: TransactionType.Other,
       txSubType: result.type,
@@ -52,7 +58,7 @@ export class BluefinHelper implements IAppHelperInternalLegacy<BluefinIntentionD
     suiClient: SuiClient;
     account: WalletAccount;
     network: SuiNetworks;
-  }): Promise<TransactionBlock> {
+  }): Promise<Transaction> {
     const { suiClient, account, network } = input;
 
     let intention: BluefinIntention;
@@ -61,27 +67,27 @@ export class BluefinHelper implements IAppHelperInternalLegacy<BluefinIntentionD
         intention = OpenAndAddLiquidity.fromData(input.intentionData);
         break;
 
-      // case TransactionSubType.ProvideLiquidity:
-      //   intention = ProvideLiquidity.fromData(input.intentionData);
-      //   break;
+      case TransactionSubType.ProvideLiquidity:
+        intention = ProvideLiquidity.fromData(input.intentionData);
+        break;
 
-      // case TransactionSubType.RemoveLiquidity:
-      //   intention = RemoveLiquidity.fromData(input.intentionData);
-      //   break;
+      case TransactionSubType.RemoveLiquidity:
+        intention = RemoveLiquidity.fromData(input.intentionData);
+        break;
 
-      // case TransactionSubType.ClosePosition:
-      //   intention = ClosePosition.fromData(input.intentionData);
-      //   break;
+      case TransactionSubType.ClosePosition:
+        intention = ClosePosition.fromData(input.intentionData);
+        break;
 
-      // case TransactionSubType.CollectFee:
-      //   intention = CollectFee.fromData(input.intentionData);
-      //   break;
-      // case TransactionSubType.CollectRewards:
-      //   intention = CollectRewards.fromData(input.intentionData);
-      //   break;
-      // case TransactionSubType.CollectFeeAndRewards:
-      //   intention = CollectFeeAndRewards.fromData(input.intentionData);
-      //   break;
+      case TransactionSubType.CollectFee:
+        intention = CollectFee.fromData(input.intentionData);
+        break;
+      case TransactionSubType.CollectRewards:
+        intention = CollectRewards.fromData(input.intentionData);
+        break;
+      case TransactionSubType.CollectFeeAndRewards:
+        intention = CollectFeeAndRewards.fromData(input.intentionData);
+        break;
       default:
         throw new Error('not implemented');
     }

--- a/src/apps/bluefin/intentions/close-position.ts
+++ b/src/apps/bluefin/intentions/close-position.ts
@@ -1,30 +1,30 @@
-// import { TransactionType } from '@msafe/sui3-utils';
-// import { SuiClient } from '@mysten/sui/client';
-// import { Transaction } from '@mysten/sui/transactions';
-// import { WalletAccount } from '@mysten/wallet-standard';
+import { TransactionType } from '@msafe/sui3-utils';
+import { SuiClient } from '@mysten/sui/client';
+import { Transaction } from '@mysten/sui/transactions';
+import { WalletAccount } from '@mysten/wallet-standard';
 
-// import { BaseIntention } from '@/apps/interface/sui';
+import { BaseIntention } from '@/apps/interface/sui';
 
-// import TxBuilder from '../tx-builder';
-// import { SuiNetworks, TransactionSubType, BluefinIntentionData } from '../types';
+import TxBuilder from '../tx-builder';
+import { SuiNetworks, TransactionSubType, BluefinIntentionData } from '../types';
 
-// export class ClosePosition extends BaseIntention<BluefinIntentionData> {
-//   txType = TransactionType.Other;
+export class ClosePosition extends BaseIntention<BluefinIntentionData> {
+  txType = TransactionType.Other;
 
-//   txSubType = TransactionSubType.ClosePosition;
+  txSubType = TransactionSubType.ClosePosition;
 
-//   constructor(public readonly data: BluefinIntentionData) {
-//     super(data);
-//   }
+  constructor(public readonly data: BluefinIntentionData) {
+    super(data);
+  }
 
-//   async build(input: { network: SuiNetworks; suiClient: SuiClient; account: WalletAccount }): Promise<Transaction> {
-//     const { account, network } = input;
-//     const { txbParams } = this.data;
-//     const txb = await TxBuilder.closePosition(txbParams, account, network);
-//     return txb;
-//   }
+  async build(input: { network: SuiNetworks; suiClient: SuiClient; account: WalletAccount }): Promise<Transaction> {
+    const { account, network } = input;
+    const { txbParams } = this.data;
+    const txb = await TxBuilder.closePosition(txbParams, account, network);
+    return txb;
+  }
 
-//   static fromData(data: BluefinIntentionData) {
-//     return new ClosePosition(data);
-//   }
-// }
+  static fromData(data: BluefinIntentionData) {
+    return new ClosePosition(data);
+  }
+}

--- a/src/apps/bluefin/intentions/collect-fee-and-rewards.ts
+++ b/src/apps/bluefin/intentions/collect-fee-and-rewards.ts
@@ -1,30 +1,30 @@
-// import { TransactionType } from '@msafe/sui3-utils';
-// import { SuiClient } from '@mysten/sui/client';
-// import { Transaction } from '@mysten/sui/transactions';
-// import { WalletAccount } from '@mysten/wallet-standard';
+import { TransactionType } from '@msafe/sui3-utils';
+import { SuiClient } from '@mysten/sui/client';
+import { Transaction } from '@mysten/sui/transactions';
+import { WalletAccount } from '@mysten/wallet-standard';
 
-// import { BaseIntention } from '@/apps/interface/sui';
+import { BaseIntention } from '@/apps/interface/sui';
 
-// import TxBuilder from '../tx-builder';
-// import { SuiNetworks, TransactionSubType, BluefinIntentionData } from '../types';
+import TxBuilder from '../tx-builder';
+import { SuiNetworks, TransactionSubType, BluefinIntentionData } from '../types';
 
-// export class CollectFeeAndRewards extends BaseIntention<BluefinIntentionData> {
-//   txType = TransactionType.Other;
+export class CollectFeeAndRewards extends BaseIntention<BluefinIntentionData> {
+  txType = TransactionType.Other;
 
-//   txSubType = TransactionSubType.CollectFeeAndRewards;
+  txSubType = TransactionSubType.CollectFeeAndRewards;
 
-//   constructor(public readonly data: BluefinIntentionData) {
-//     super(data);
-//   }
+  constructor(public readonly data: BluefinIntentionData) {
+    super(data);
+  }
 
-//   async build(input: { network: SuiNetworks; suiClient: SuiClient; account: WalletAccount }): Promise<Transaction> {
-//     const { account, network } = input;
-//     const { txbParams } = this.data;
-//     const txb = await TxBuilder.collectFeeAndRewards(txbParams, account, network);
-//     return txb;
-//   }
+  async build(input: { network: SuiNetworks; suiClient: SuiClient; account: WalletAccount }): Promise<Transaction> {
+    const { account, network } = input;
+    const { txbParams } = this.data;
+    const txb = await TxBuilder.collectFeeAndRewards(txbParams, account, network);
+    return txb;
+  }
 
-//   static fromData(data: BluefinIntentionData) {
-//     return new CollectFeeAndRewards(data);
-//   }
-// }
+  static fromData(data: BluefinIntentionData) {
+    return new CollectFeeAndRewards(data);
+  }
+}

--- a/src/apps/bluefin/intentions/collect-fee.ts
+++ b/src/apps/bluefin/intentions/collect-fee.ts
@@ -1,30 +1,30 @@
-// import { TransactionType } from '@msafe/sui3-utils';
-// import { SuiClient } from '@mysten/sui/client';
-// import { Transaction } from '@mysten/sui/transactions';
-// import { WalletAccount } from '@mysten/wallet-standard';
+import { TransactionType } from '@msafe/sui3-utils';
+import { SuiClient } from '@mysten/sui/client';
+import { Transaction } from '@mysten/sui/transactions';
+import { WalletAccount } from '@mysten/wallet-standard';
 
-// import { BaseIntention } from '@/apps/interface/sui';
+import { BaseIntention } from '@/apps/interface/sui';
 
-// import TxBuilder from '../tx-builder';
-// import { SuiNetworks, TransactionSubType, BluefinIntentionData } from '../types';
+import TxBuilder from '../tx-builder';
+import { SuiNetworks, TransactionSubType, BluefinIntentionData } from '../types';
 
-// export class CollectFee extends BaseIntention<BluefinIntentionData> {
-//   txType = TransactionType.Other;
+export class CollectFee extends BaseIntention<BluefinIntentionData> {
+  txType = TransactionType.Other;
 
-//   txSubType = TransactionSubType.CollectFee;
+  txSubType = TransactionSubType.CollectFee;
 
-//   constructor(public readonly data: BluefinIntentionData) {
-//     super(data);
-//   }
+  constructor(public readonly data: BluefinIntentionData) {
+    super(data);
+  }
 
-//   async build(input: { network: SuiNetworks; suiClient: SuiClient; account: WalletAccount }): Promise<Transaction> {
-//     const { account, network } = input;
-//     const { txbParams } = this.data;
-//     const txb = await TxBuilder.collectFee(txbParams, account, network);
-//     return txb;
-//   }
+  async build(input: { network: SuiNetworks; suiClient: SuiClient; account: WalletAccount }): Promise<Transaction> {
+    const { account, network } = input;
+    const { txbParams } = this.data;
+    const txb = await TxBuilder.collectFee(txbParams, account, network);
+    return txb;
+  }
 
-//   static fromData(data: BluefinIntentionData) {
-//     return new CollectFee(data);
-//   }
-// }
+  static fromData(data: BluefinIntentionData) {
+    return new CollectFee(data);
+  }
+}

--- a/src/apps/bluefin/intentions/collect-rewards.ts
+++ b/src/apps/bluefin/intentions/collect-rewards.ts
@@ -1,30 +1,30 @@
-// import { TransactionType } from '@msafe/sui3-utils';
-// import { SuiClient } from '@mysten/sui/client';
-// import { Transaction } from '@mysten/sui/transactions';
-// import { WalletAccount } from '@mysten/wallet-standard';
+import { TransactionType } from '@msafe/sui3-utils';
+import { SuiClient } from '@mysten/sui/client';
+import { Transaction } from '@mysten/sui/transactions';
+import { WalletAccount } from '@mysten/wallet-standard';
 
-// import { BaseIntention } from '@/apps/interface/sui';
+import { BaseIntention } from '@/apps/interface/sui';
 
-// import TxBuilder from '../tx-builder';
-// import { SuiNetworks, TransactionSubType, BluefinIntentionData } from '../types';
+import TxBuilder from '../tx-builder';
+import { SuiNetworks, TransactionSubType, BluefinIntentionData } from '../types';
 
-// export class CollectRewards extends BaseIntention<BluefinIntentionData> {
-//   txType = TransactionType.Other;
+export class CollectRewards extends BaseIntention<BluefinIntentionData> {
+  txType = TransactionType.Other;
 
-//   txSubType = TransactionSubType.CollectRewards;
+  txSubType = TransactionSubType.CollectRewards;
 
-//   constructor(public readonly data: BluefinIntentionData) {
-//     super(data);
-//   }
+  constructor(public readonly data: BluefinIntentionData) {
+    super(data);
+  }
 
-//   async build(input: { network: SuiNetworks; suiClient: SuiClient; account: WalletAccount }): Promise<Transaction> {
-//     const { account, network } = input;
-//     const { txbParams } = this.data;
-//     const txb = await TxBuilder.collectRewards(txbParams, account, network);
-//     return txb;
-//   }
+  async build(input: { network: SuiNetworks; suiClient: SuiClient; account: WalletAccount }): Promise<Transaction> {
+    const { account, network } = input;
+    const { txbParams } = this.data;
+    const txb = await TxBuilder.collectRewards(txbParams, account, network);
+    return txb;
+  }
 
-//   static fromData(data: BluefinIntentionData) {
-//     return new CollectRewards(data);
-//   }
-// }
+  static fromData(data: BluefinIntentionData) {
+    return new CollectRewards(data);
+  }
+}

--- a/src/apps/bluefin/intentions/open-position-with-liquidity.ts
+++ b/src/apps/bluefin/intentions/open-position-with-liquidity.ts
@@ -1,14 +1,14 @@
 import { TransactionType } from '@msafe/sui3-utils';
-import { SuiClient } from '@mysten/sui.js/client';
-import { TransactionBlock } from '@mysten/sui.js/transactions';
+import { SuiClient } from '@mysten/sui/client';
+import { Transaction } from '@mysten/sui/transactions';
 import { WalletAccount } from '@mysten/wallet-standard';
 
-import { BaseIntentionLegacy } from '@/apps/interface/sui-js';
+import { BaseIntention } from '@/apps/interface/sui';
 
 import TxBuilder from '../tx-builder';
 import { SuiNetworks, TransactionSubType, BluefinIntentionData } from '../types';
 
-export class OpenAndAddLiquidity extends BaseIntentionLegacy<BluefinIntentionData> {
+export class OpenAndAddLiquidity extends BaseIntention<BluefinIntentionData> {
   txType = TransactionType.Other;
 
   txSubType = TransactionSubType.OpenAndAddLiquidity;
@@ -17,14 +17,11 @@ export class OpenAndAddLiquidity extends BaseIntentionLegacy<BluefinIntentionDat
     super(data);
   }
 
-  async build(input: {
-    network: SuiNetworks;
-    suiClient: SuiClient;
-    account: WalletAccount;
-  }): Promise<TransactionBlock> {
+  async build(input: { network: SuiNetworks; suiClient: SuiClient; account: WalletAccount }): Promise<Transaction> {
     const { account, network } = input;
     const { txbParams } = this.data;
-    return TxBuilder.openPositionAndAddLiquidity(txbParams, account, network);
+    const txb = await TxBuilder.openPositionAndAddLiquidity(txbParams, account, network);
+    return txb;
   }
 
   static fromData(data: BluefinIntentionData) {

--- a/src/apps/bluefin/intentions/provide-liquidity.ts
+++ b/src/apps/bluefin/intentions/provide-liquidity.ts
@@ -1,33 +1,30 @@
-// import { TransactionType } from '@msafe/sui3-utils';
-// import { SuiClient } from '@mysten/sui.js/client';
-// import { TransactionBlock } from '@mysten/sui.js/transactions';
-// import { WalletAccount } from '@mysten/wallet-standard';
+import { TransactionType } from '@msafe/sui3-utils';
+import { SuiClient } from '@mysten/sui/client';
+import { Transaction } from '@mysten/sui/transactions';
+import { WalletAccount } from '@mysten/wallet-standard';
 
-// import { BaseIntentionLegacy } from '@/apps/interface/sui-js';
+import { BaseIntention } from '@/apps/interface/sui';
 
-// import TxBuilder from '../tx-builder';
-// import { SuiNetworks, TransactionSubType, BluefinIntentionData } from '../types';
+import TxBuilder from '../tx-builder';
+import { SuiNetworks, TransactionSubType, BluefinIntentionData } from '../types';
 
-// export class ProvideLiquidity extends BaseIntentionLegacy<BluefinIntentionData> {
-//   txType = TransactionType.Other;
+export class ProvideLiquidity extends BaseIntention<BluefinIntentionData> {
+  txType = TransactionType.Other;
 
-//   txSubType = TransactionSubType.ProvideLiquidity;
+  txSubType = TransactionSubType.ProvideLiquidity;
 
-//   constructor(public readonly data: BluefinIntentionData) {
-//     super(data);
-//   }
+  constructor(public readonly data: BluefinIntentionData) {
+    super(data);
+  }
 
-//   async build(input: {
-//     network: SuiNetworks;
-//     suiClient: SuiClient;
-//     account: WalletAccount;
-//   }): Promise<TransactionBlock> {
-//     const { account, network } = input;
-//     const { txbParams } = this.data;
-//     return TxBuilder.provideLiquidity(txbParams, account, network);
-//   }
+  async build(input: { network: SuiNetworks; suiClient: SuiClient; account: WalletAccount }): Promise<Transaction> {
+    const { account, network } = input;
+    const { txbParams } = this.data;
+    const txb = await TxBuilder.provideLiquidity(txbParams, account, network);
+    return txb;
+  }
 
-//   static fromData(data: BluefinIntentionData) {
-//     return new ProvideLiquidity(data);
-//   }
-// }
+  static fromData(data: BluefinIntentionData) {
+    return new ProvideLiquidity(data);
+  }
+}

--- a/src/apps/bluefin/intentions/remove-liquidity.ts
+++ b/src/apps/bluefin/intentions/remove-liquidity.ts
@@ -1,30 +1,30 @@
-// import { TransactionType } from '@msafe/sui3-utils';
-// import { SuiClient } from '@mysten/sui/client';
-// import { Transaction } from '@mysten/sui/transactions';
-// import { WalletAccount } from '@mysten/wallet-standard';
+import { TransactionType } from '@msafe/sui3-utils';
+import { SuiClient } from '@mysten/sui/client';
+import { Transaction } from '@mysten/sui/transactions';
+import { WalletAccount } from '@mysten/wallet-standard';
 
-// import { BaseIntention } from '@/apps/interface/sui';
+import { BaseIntention } from '@/apps/interface/sui';
 
-// import TxBuilder from '../tx-builder';
-// import { SuiNetworks, TransactionSubType, BluefinIntentionData } from '../types';
+import TxBuilder from '../tx-builder';
+import { SuiNetworks, TransactionSubType, BluefinIntentionData } from '../types';
 
-// export class RemoveLiquidity extends BaseIntention<BluefinIntentionData> {
-//   txType = TransactionType.Other;
+export class RemoveLiquidity extends BaseIntention<BluefinIntentionData> {
+  txType = TransactionType.Other;
 
-//   txSubType = TransactionSubType.RemoveLiquidity;
+  txSubType = TransactionSubType.RemoveLiquidity;
 
-//   constructor(public readonly data: BluefinIntentionData) {
-//     super(data);
-//   }
+  constructor(public readonly data: BluefinIntentionData) {
+    super(data);
+  }
 
-//   async build(input: { network: SuiNetworks; suiClient: SuiClient; account: WalletAccount }): Promise<Transaction> {
-//     const { account, network } = input;
-//     const { txbParams } = this.data;
-//     const txb = await TxBuilder.removeLiquidity(txbParams, account, network);
-//     return txb;
-//   }
+  async build(input: { network: SuiNetworks; suiClient: SuiClient; account: WalletAccount }): Promise<Transaction> {
+    const { account, network } = input;
+    const { txbParams } = this.data;
+    const txb = await TxBuilder.removeLiquidity(txbParams, account, network);
+    return txb;
+  }
 
-//   static fromData(data: BluefinIntentionData) {
-//     return new RemoveLiquidity(data);
-//   }
-// }
+  static fromData(data: BluefinIntentionData) {
+    return new RemoveLiquidity(data);
+  }
+}

--- a/src/apps/bluefin/tx-builder.ts
+++ b/src/apps/bluefin/tx-builder.ts
@@ -1,6 +1,6 @@
-import { BN, ClmmPoolUtil, LiquidityInput, Transaction } from '@firefly-exchange/library-sui';
+import { BN, ClmmPoolUtil, LiquidityInput } from '@firefly-exchange/library-sui';
 import { Pool } from '@firefly-exchange/library-sui/dist/src/spot/types';
-import { TransactionBlock } from '@mysten/sui.js/transactions';
+import { Transaction } from '@mysten/sui/transactions';
 import { WalletAccount } from '@mysten/wallet-standard';
 
 import { getBluefinSpotSDK } from './config';
@@ -11,34 +11,34 @@ export default class TxBuilder {
     txbParams: any,
     account: WalletAccount,
     network: SuiNetworks,
-  ): Promise<TransactionBlock> {
+  ): Promise<Transaction> {
     const sdk = getBluefinSpotSDK(network, account);
 
     const pool = await sdk.queryChain.getPool(txbParams.pool);
 
     const res = this.prototype.buildLiqInput(pool, { ...txbParams, slippage: 0 });
 
-    const txb = (await sdk.openPositionWithFixedAmount(pool, txbParams.lowerTick, txbParams.upperTick, res, {
-      returnTx: true,
-    })) as any as TransactionBlock;
+    const txb: Transaction = (await sdk.openPositionWithFixedAmount(
+      pool,
+      txbParams.lowerTick,
+      txbParams.upperTick,
+      res,
+      { returnTx: true },
+    )) as any as Transaction;
 
     return txb;
   }
 
-  static async provideLiquidity(
-    txbParams: any,
-    account: WalletAccount,
-    network: SuiNetworks,
-  ): Promise<TransactionBlock> {
+  static async provideLiquidity(txbParams: any, account: WalletAccount, network: SuiNetworks): Promise<Transaction> {
     const sdk = getBluefinSpotSDK(network, account);
 
     const pool = await sdk.queryChain.getPool(txbParams.pool);
 
     const res = this.prototype.buildLiqInput(pool, txbParams);
 
-    const txb: TransactionBlock = (await sdk.provideLiquidityWithFixedAmount(pool, txbParams.position, res, {
+    const txb: Transaction = (await sdk.provideLiquidityWithFixedAmount(pool, txbParams.position, res, {
       returnTx: true,
-    })) as any as TransactionBlock;
+    })) as any as Transaction;
 
     return txb;
   }

--- a/test/bluefin.test.ts
+++ b/test/bluefin.test.ts
@@ -3,16 +3,17 @@ import { HexToUint8Array, TransactionType } from '@msafe/sui3-utils';
 import { SUI_MAINNET_CHAIN, WalletAccount } from '@mysten/wallet-standard';
 
 import { BluefinHelper } from '@/apps/bluefin/helper';
-// import { ClosePosition } from '@/apps/bluefin/intentions/close-position';
-// import { CollectFee } from '@/apps/bluefin/intentions/collect-fee';
-// import { CollectFeeAndRewards } from '@/apps/bluefin/intentions/collect-fee-and-rewards';
-// import { CollectRewards } from '@/apps/bluefin/intentions/collect-rewards';
+import { ClosePosition } from '@/apps/bluefin/intentions/close-position';
+import { CollectFee } from '@/apps/bluefin/intentions/collect-fee';
+import { CollectFeeAndRewards } from '@/apps/bluefin/intentions/collect-fee-and-rewards';
+import { CollectRewards } from '@/apps/bluefin/intentions/collect-rewards';
 import { OpenAndAddLiquidity } from '@/apps/bluefin/intentions/open-position-with-liquidity';
-// import { ProvideLiquidity } from '@/apps/bluefin/intentions/provide-liquidity';
-// import { RemoveLiquidity } from '@/apps/bluefin/intentions/remove-liquidity';
+import { ProvideLiquidity } from '@/apps/bluefin/intentions/provide-liquidity';
+import { RemoveLiquidity } from '@/apps/bluefin/intentions/remove-liquidity';
+import TxBuilder from '@/apps/bluefin/tx-builder';
 import { BluefinIntentionData, TransactionSubType } from '@/apps/bluefin/types';
 
-import { TestSuiteLegacy } from './testSuite';
+import { TestSuite } from './testSuite';
 
 describe('Bluefin App', () => {
   it('Test `OpenAndAddLiquidity` intention serialization', () => {
@@ -34,93 +35,93 @@ describe('Bluefin App', () => {
   });
 
 
-  // it('Test `ProvideLiquidity` intention serialization', () => {
-  //   const intention = ProvideLiquidity.fromData({
-  //     txbParams: {
-  //       pool: '0x0c89fd0320b406311c05f1ed8c4656b4ab7ed14999a992cc6c878c2fad405140',
-  //       position: '0x56b4ab7ed14999a992cc6c878c2fad4051400c89fd0320b406311c05f1ed8c46',
-  //       lowerTick: 1,
-  //       upperTick: 2,
-  //       tokenAmount: 0.5,
-  //       isCoinA: true,
-  //       slippage: 0.025,
-  //     },
-  //     action: TransactionSubType.ProvideLiquidity,
-  //   });
-  //   expect(intention.serialize()).toBe(
-  //     '{"action":"ProvideLiquidity","txbParams":{"isCoinA":true,"lowerTick":1,"pool":"0x0c89fd0320b406311c05f1ed8c4656b4ab7ed14999a992cc6c878c2fad405140","position":"0x56b4ab7ed14999a992cc6c878c2fad4051400c89fd0320b406311c05f1ed8c46","slippage":0.025,"tokenAmount":0.5,"upperTick":2}}',
-  //   );
-  // });
+  it('Test `ProvideLiquidity` intention serialization', () => {
+    const intention = ProvideLiquidity.fromData({
+      txbParams: {
+        pool: '0x0c89fd0320b406311c05f1ed8c4656b4ab7ed14999a992cc6c878c2fad405140',
+        position: '0x56b4ab7ed14999a992cc6c878c2fad4051400c89fd0320b406311c05f1ed8c46',
+        lowerTick: 1,
+        upperTick: 2,
+        tokenAmount: 0.5,
+        isCoinA: true,
+        slippage: 0.025,
+      },
+      action: TransactionSubType.ProvideLiquidity,
+    });
+    expect(intention.serialize()).toBe(
+      '{"action":"ProvideLiquidity","txbParams":{"isCoinA":true,"lowerTick":1,"pool":"0x0c89fd0320b406311c05f1ed8c4656b4ab7ed14999a992cc6c878c2fad405140","position":"0x56b4ab7ed14999a992cc6c878c2fad4051400c89fd0320b406311c05f1ed8c46","slippage":0.025,"tokenAmount":0.5,"upperTick":2}}',
+    );
+  });
 
-  // it('Test `RemoveLiquidity` intention serialization', () => {
-  //   const intention = RemoveLiquidity.fromData({
-  //     txbParams: {
-  //       pool: '0x0c89fd0320b406311c05f1ed8c4656b4ab7ed14999a992cc6c878c2fad405140',
-  //       position: '0x56b4ab7ed14999a992cc6c878c2fad4051400c89fd0320b406311c05f1ed8c46',
-  //       lowerTick: 1,
-  //       upperTick: 2,
-  //       tokenAmount: 0.5,
-  //       isCoinA: true,
-  //       slippage: 0.025,
-  //     },
-  //     action: TransactionSubType.RemoveLiquidity,
-  //   });
-  //   expect(intention.serialize()).toBe(
-  //     '{"action":"RemoveLiquidity","txbParams":{"isCoinA":true,"lowerTick":1,"pool":"0x0c89fd0320b406311c05f1ed8c4656b4ab7ed14999a992cc6c878c2fad405140","position":"0x56b4ab7ed14999a992cc6c878c2fad4051400c89fd0320b406311c05f1ed8c46","slippage":0.025,"tokenAmount":0.5,"upperTick":2}}',
-  //   );
-  // });
+  it('Test `RemoveLiquidity` intention serialization', () => {
+    const intention = RemoveLiquidity.fromData({
+      txbParams: {
+        pool: '0x0c89fd0320b406311c05f1ed8c4656b4ab7ed14999a992cc6c878c2fad405140',
+        position: '0x56b4ab7ed14999a992cc6c878c2fad4051400c89fd0320b406311c05f1ed8c46',
+        lowerTick: 1,
+        upperTick: 2,
+        tokenAmount: 0.5,
+        isCoinA: true,
+        slippage: 0.025,
+      },
+      action: TransactionSubType.RemoveLiquidity,
+    });
+    expect(intention.serialize()).toBe(
+      '{"action":"RemoveLiquidity","txbParams":{"isCoinA":true,"lowerTick":1,"pool":"0x0c89fd0320b406311c05f1ed8c4656b4ab7ed14999a992cc6c878c2fad405140","position":"0x56b4ab7ed14999a992cc6c878c2fad4051400c89fd0320b406311c05f1ed8c46","slippage":0.025,"tokenAmount":0.5,"upperTick":2}}',
+    );
+  });
 
-  // it('Test `ClosePosition` intention serialization', () => {
-  //   const intention = ClosePosition.fromData({
-  //     txbParams: {
-  //       pool: '0x0c89fd0320b406311c05f1ed8c4656b4ab7ed14999a992cc6c878c2fad405140',
-  //       position: '0x56b4ab7ed14999a992cc6c878c2fad4051400c89fd0320b406311c05f1ed8c46',
-  //     },
-  //     action: TransactionSubType.ClosePosition,
-  //   });
-  //   expect(intention.serialize()).toBe(
-  //     '{"action":"ClosePosition","txbParams":{"pool":"0x0c89fd0320b406311c05f1ed8c4656b4ab7ed14999a992cc6c878c2fad405140","position":"0x56b4ab7ed14999a992cc6c878c2fad4051400c89fd0320b406311c05f1ed8c46"}}',
-  //   );
-  // });
+  it('Test `ClosePosition` intention serialization', () => {
+    const intention = ClosePosition.fromData({
+      txbParams: {
+        pool: '0x0c89fd0320b406311c05f1ed8c4656b4ab7ed14999a992cc6c878c2fad405140',
+        position: '0x56b4ab7ed14999a992cc6c878c2fad4051400c89fd0320b406311c05f1ed8c46',
+      },
+      action: TransactionSubType.ClosePosition,
+    });
+    expect(intention.serialize()).toBe(
+      '{"action":"ClosePosition","txbParams":{"pool":"0x0c89fd0320b406311c05f1ed8c4656b4ab7ed14999a992cc6c878c2fad405140","position":"0x56b4ab7ed14999a992cc6c878c2fad4051400c89fd0320b406311c05f1ed8c46"}}',
+    );
+  });
 
-  // it('Test `CollectFee` intention serialization', () => {
-  //   const intention = CollectFee.fromData({
-  //     txbParams: {
-  //       pool: '0x0c89fd0320b406311c05f1ed8c4656b4ab7ed14999a992cc6c878c2fad405140',
-  //       position: '0x56b4ab7ed14999a992cc6c878c2fad4051400c89fd0320b406311c05f1ed8c46',
-  //     },
-  //     action: TransactionSubType.CollectFee,
-  //   });
-  //   expect(intention.serialize()).toBe(
-  //     '{"action":"CollectFee","txbParams":{"pool":"0x0c89fd0320b406311c05f1ed8c4656b4ab7ed14999a992cc6c878c2fad405140","position":"0x56b4ab7ed14999a992cc6c878c2fad4051400c89fd0320b406311c05f1ed8c46"}}',
-  //   );
-  // });
+  it('Test `CollectFee` intention serialization', () => {
+    const intention = CollectFee.fromData({
+      txbParams: {
+        pool: '0x0c89fd0320b406311c05f1ed8c4656b4ab7ed14999a992cc6c878c2fad405140',
+        position: '0x56b4ab7ed14999a992cc6c878c2fad4051400c89fd0320b406311c05f1ed8c46',
+      },
+      action: TransactionSubType.CollectFee,
+    });
+    expect(intention.serialize()).toBe(
+      '{"action":"CollectFee","txbParams":{"pool":"0x0c89fd0320b406311c05f1ed8c4656b4ab7ed14999a992cc6c878c2fad405140","position":"0x56b4ab7ed14999a992cc6c878c2fad4051400c89fd0320b406311c05f1ed8c46"}}',
+    );
+  });
 
-  // it('Test `CollectRewards` intention serialization', () => {
-  //   const intention = CollectRewards.fromData({
-  //     txbParams: {
-  //       pool: '0x0c89fd0320b406311c05f1ed8c4656b4ab7ed14999a992cc6c878c2fad405140',
-  //       position: '0x56b4ab7ed14999a992cc6c878c2fad4051400c89fd0320b406311c05f1ed8c46',
-  //     },
-  //     action: TransactionSubType.CollectRewards,
-  //   });
-  //   expect(intention.serialize()).toBe(
-  //     '{"action":"CollectRewards","txbParams":{"pool":"0x0c89fd0320b406311c05f1ed8c4656b4ab7ed14999a992cc6c878c2fad405140","position":"0x56b4ab7ed14999a992cc6c878c2fad4051400c89fd0320b406311c05f1ed8c46"}}',
-  //   );
-  // });
+  it('Test `CollectRewards` intention serialization', () => {
+    const intention = CollectRewards.fromData({
+      txbParams: {
+        pool: '0x0c89fd0320b406311c05f1ed8c4656b4ab7ed14999a992cc6c878c2fad405140',
+        position: '0x56b4ab7ed14999a992cc6c878c2fad4051400c89fd0320b406311c05f1ed8c46',
+      },
+      action: TransactionSubType.CollectRewards,
+    });
+    expect(intention.serialize()).toBe(
+      '{"action":"CollectRewards","txbParams":{"pool":"0x0c89fd0320b406311c05f1ed8c4656b4ab7ed14999a992cc6c878c2fad405140","position":"0x56b4ab7ed14999a992cc6c878c2fad4051400c89fd0320b406311c05f1ed8c46"}}',
+    );
+  });
 
-  // it('Test `CollectFeeAndRewards` intention serialization', () => {
-  //   const intention = CollectFeeAndRewards.fromData({
-  //     txbParams: {
-  //       pool: '0x0c89fd0320b406311c05f1ed8c4656b4ab7ed14999a992cc6c878c2fad405140',
-  //       position: '0x56b4ab7ed14999a992cc6c878c2fad4051400c89fd0320b406311c05f1ed8c46',
-  //     },
-  //     action: TransactionSubType.CollectFeeAndRewards,
-  //   });
-  //   expect(intention.serialize()).toBe(
-  //     '{"action":"CollectFeeAndRewards","txbParams":{"pool":"0x0c89fd0320b406311c05f1ed8c4656b4ab7ed14999a992cc6c878c2fad405140","position":"0x56b4ab7ed14999a992cc6c878c2fad4051400c89fd0320b406311c05f1ed8c46"}}',
-  //   );
-  // });
+  it('Test `CollectFeeAndRewards` intention serialization', () => {
+    const intention = CollectFeeAndRewards.fromData({
+      txbParams: {
+        pool: '0x0c89fd0320b406311c05f1ed8c4656b4ab7ed14999a992cc6c878c2fad405140',
+        position: '0x56b4ab7ed14999a992cc6c878c2fad4051400c89fd0320b406311c05f1ed8c46',
+      },
+      action: TransactionSubType.CollectFeeAndRewards,
+    });
+    expect(intention.serialize()).toBe(
+      '{"action":"CollectFeeAndRewards","txbParams":{"pool":"0x0c89fd0320b406311c05f1ed8c4656b4ab7ed14999a992cc6c878c2fad405140","position":"0x56b4ab7ed14999a992cc6c878c2fad4051400c89fd0320b406311c05f1ed8c46"}}',
+    );
+  });
 
   describe('Deserialization', ()=>{
 
@@ -135,503 +136,24 @@ describe('Bluefin App', () => {
 
 
     it("Deserialize OpenPositionAndProvideLiquidity transaction", async()=> {
-      
-      const transaction = {
-        blockData: {
-          "version": 1,
-        "sender": "0x4c0a9ef46ff24d003debdf5953234b19109264ae511746e56b7a279e3d2cfbc9",
-        "expiration": {
-            "None": true
-        },
-        "gasConfig": {
-            "owner": "0x4c0a9ef46ff24d003debdf5953234b19109264ae511746e56b7a279e3d2cfbc9",
-            "budget": "8123552",
-            "price": "750",
-            "payment": [
-                {
-                    "objectId": "0x69c4a4e110d10a90c818f03badefd1aff89f0a738f29a83d7a81571f55db3bbf",
-                    "version": "441334191",
-                    "digest": "Hj6zKRjHo7oUf173ovuahqU3WwtgkpBbEVpygxn9cGi9"
-                },
-                {
-                    "objectId": "0x29aa62f6c576dcba843636d43b4ffeb7a134dc9644870d0402d793365a201d8f",
-                    "version": "441334190",
-                    "digest": "EE3Mam6pWKRm8HQEpAQJiKam3DGLrTQ4suvpM1ehsVFU"
-                }
-            ]
-        },
-        "inputs": [
-            {
-                "kind": "Input",
-                "index": 0,
-                "value": {
-                    "Object": {
-                        "Shared": {
-                            "mutable": false,
-                            "initialSharedVersion": "406496849",
-                            "objectId": "0x03db251ba509a8d5d8777b6338836082335d93eecbdd09a11e190a1cff51c352"
-                        }
-                    }
-                },
-                "type": "object"
-            },
-            {
-                "kind": "Input",
-                "index": 1,
-                "value": {
-                    "Object": {
-                        "Shared": {
-                            "mutable": true,
-                            "initialSharedVersion": "406731547",
-                            "objectId": "0x3b585786b13af1d8ea067ab37101b6513a05d2f90cfe60e8b1d9e1b46a63c4fa"
-                        }
-                    }
-                },
-                "type": "object"
-            },
-            {
-                "kind": "Input",
-                "index": 2,
-                "value": {
-                    "Pure": [
-                        48,
-                        38,
-                        255,
-                        255
-                    ]
-                },
-                "type": "pure"
-            },
-            {
-                "kind": "Input",
-                "index": 3,
-                "value": {
-                    "Pure": [
-                        232,
-                        39,
-                        255,
-                        255
-                    ]
-                },
-                "type": "pure"
-            },
-            {
-                "kind": "Input",
-                "index": 4,
-                "value": {
-                    "Pure": [
-                        0,
-                        225,
-                        245,
-                        5,
-                        0,
-                        0,
-                        0,
-                        0
-                    ]
-                },
-                "type": "pure"
-            },
-            {
-                "kind": "Input",
-                "index": 5,
-                "value": {
-                    "Object": {
-                        "Shared": {
-                            "mutable": false,
-                            "initialSharedVersion": "1",
-                            "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006"
-                        }
-                    }
-                },
-                "type": "object"
-            },
-            {
-                "kind": "Input",
-                "index": 6,
-                "value": {
-                    "Pure": [
-                        0,
-                        225,
-                        245,
-                        5,
-                        0,
-                        0,
-                        0,
-                        0
-                    ]
-                },
-                "type": "pure"
-            },
-            {
-                "kind": "Input",
-                "index": 7,
-                "value": {
-                    "Pure": [
-                        0,
-                        225,
-                        245,
-                        5,
-                        0,
-                        0,
-                        0,
-                        0
-                    ]
-                },
-                "type": "pure"
-            },
-            {
-                "kind": "Input",
-                "index": 8,
-                "value": {
-                    "Pure": [
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0,
-                        0
-                    ]
-                },
-                "type": "pure"
-            },
-            {
-                "kind": "Input",
-                "index": 9,
-                "value": {
-                    "Pure": [
-                        1
-                    ]
-                },
-                "type": "pure"
-            },
-            {
-                "kind": "Input",
-                "index": 10,
-                "value": {
-                    "Pure": [
-                        76,
-                        10,
-                        158,
-                        244,
-                        111,
-                        242,
-                        77,
-                        0,
-                        61,
-                        235,
-                        223,
-                        89,
-                        83,
-                        35,
-                        75,
-                        25,
-                        16,
-                        146,
-                        100,
-                        174,
-                        81,
-                        23,
-                        70,
-                        229,
-                        107,
-                        122,
-                        39,
-                        158,
-                        61,
-                        44,
-                        251,
-                        201
-                    ]
-                },
-                "type": "pure"
-            }
-        ],
-        "transactions": [
-            {
-                "kind": "MoveCall",
-                "target": "0xa31282fc0a0ad50cf5f20908cfbb1539a143f5a38912eb8823a8dd6cbf98bc44::pool::open_position",
-                "typeArguments": [
-                    "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
-                    "0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC"
-                ],
-                "arguments": [
-                    {
-                        "kind": "Input",
-                        "index": 0,
-                        "value": {
-                            "Object": {
-                                "Shared": {
-                                    "mutable": false,
-                                    "initialSharedVersion": "406496849",
-                                    "objectId": "0x03db251ba509a8d5d8777b6338836082335d93eecbdd09a11e190a1cff51c352"
-                                }
-                            }
-                        },
-                        "type": "object"
-                    },
-                    {
-                        "kind": "Input",
-                        "index": 1,
-                        "value": {
-                            "Object": {
-                                "Shared": {
-                                    "mutable": true,
-                                    "initialSharedVersion": "406731547",
-                                    "objectId": "0x3b585786b13af1d8ea067ab37101b6513a05d2f90cfe60e8b1d9e1b46a63c4fa"
-                                }
-                            }
-                        },
-                        "type": "object"
-                    },
-                    {
-                        "kind": "Input",
-                        "index": 2,
-                        "value": {
-                            "Pure": [
-                                48,
-                                38,
-                                255,
-                                255
-                            ]
-                        },
-                        "type": "pure"
-                    },
-                    {
-                        "kind": "Input",
-                        "index": 3,
-                        "value": {
-                            "Pure": [
-                                232,
-                                39,
-                                255,
-                                255
-                            ]
-                        },
-                        "type": "pure"
-                    }
-                ]
-            },
-            {
-                "kind": "SplitCoins",
-                "coin": {
-                    "kind": "GasCoin"
-                },
-                "amounts": [
-                    {
-                        "kind": "Input",
-                        "index": 4,
-                        "value": {
-                            "Pure": [
-                                0,
-                                225,
-                                245,
-                                5,
-                                0,
-                                0,
-                                0,
-                                0
-                            ]
-                        },
-                        "type": "pure"
-                    }
-                ]
-            },
-            {
-                "kind": "MoveCall",
-                "target": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::zero",
-                "typeArguments": [
-                    "0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC"
-                ],
-                "arguments": []
-            },
-            {
-                "kind": "MoveCall",
-                "target": "0xa31282fc0a0ad50cf5f20908cfbb1539a143f5a38912eb8823a8dd6cbf98bc44::gateway::provide_liquidity_with_fixed_amount",
-                "typeArguments": [
-                    "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
-                    "0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC"
-                ],
-                "arguments": [
-                    {
-                        "kind": "Input",
-                        "index": 5,
-                        "value": {
-                            "Object": {
-                                "Shared": {
-                                    "mutable": false,
-                                    "initialSharedVersion": "1",
-                                    "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006"
-                                }
-                            }
-                        },
-                        "type": "object"
-                    },
-                    {
-                        "kind": "Input",
-                        "index": 0,
-                        "value": {
-                            "Object": {
-                                "Shared": {
-                                    "mutable": false,
-                                    "initialSharedVersion": "406496849",
-                                    "objectId": "0x03db251ba509a8d5d8777b6338836082335d93eecbdd09a11e190a1cff51c352"
-                                }
-                            }
-                        },
-                        "type": "object"
-                    },
-                    {
-                        "kind": "Input",
-                        "index": 1,
-                        "value": {
-                            "Object": {
-                                "Shared": {
-                                    "mutable": true,
-                                    "initialSharedVersion": "406731547",
-                                    "objectId": "0x3b585786b13af1d8ea067ab37101b6513a05d2f90cfe60e8b1d9e1b46a63c4fa"
-                                }
-                            }
-                        },
-                        "type": "object"
-                    },
-                    {
-                        "kind": "NestedResult",
-                        "index": 0,
-                        "resultIndex": 0
-                    },
-                    {
-                        "kind": "Result",
-                        "index": 1
-                    },
-                    {
-                        "kind": "Result",
-                        "index": 2
-                    },
-                    {
-                        "kind": "Input",
-                        "index": 6,
-                        "value": {
-                            "Pure": [
-                                0,
-                                225,
-                                245,
-                                5,
-                                0,
-                                0,
-                                0,
-                                0
-                            ]
-                        },
-                        "type": "pure"
-                    },
-                    {
-                        "kind": "Input",
-                        "index": 7,
-                        "value": {
-                            "Pure": [
-                                0,
-                                225,
-                                245,
-                                5,
-                                0,
-                                0,
-                                0,
-                                0
-                            ]
-                        },
-                        "type": "pure"
-                    },
-                    {
-                        "kind": "Input",
-                        "index": 8,
-                        "value": {
-                            "Pure": [
-                                0,
-                                0,
-                                0,
-                                0,
-                                0,
-                                0,
-                                0,
-                                0
-                            ]
-                        },
-                        "type": "pure"
-                    },
-                    {
-                        "kind": "Input",
-                        "index": 9,
-                        "value": {
-                            "Pure": [
-                                1
-                            ]
-                        },
-                        "type": "pure"
-                    }
-                ]
-            },
-            {
-                "kind": "TransferObjects",
-                "objects": [
-                    {
-                        "kind": "NestedResult",
-                        "index": 0,
-                        "resultIndex": 0
-                    }
-                ],
-                "address": {
-                    "kind": "Input",
-                    "index": 10,
-                    "value": {
-                        "Pure": [
-                            76,
-                            10,
-                            158,
-                            244,
-                            111,
-                            242,
-                            77,
-                            0,
-                            61,
-                            235,
-                            223,
-                            89,
-                            83,
-                            35,
-                            75,
-                            25,
-                            16,
-                            146,
-                            100,
-                            174,
-                            81,
-                            23,
-                            70,
-                            229,
-                            107,
-                            122,
-                            39,
-                            158,
-                            61,
-                            44,
-                            251,
-                            201
-                        ]
-                    },
-                    "type": "pure"
-                }
-            }
-        ]
-        }
-      }
 
-      const data = await helper.deserialize({transactionBlock: transaction} as any);
-
+      const transaction =  await TxBuilder.openPositionAndAddLiquidity(
+        {
+          pool: '0x0321b68a0fca8c990710d26986ba433d06b351deba9384017cd6175f20466a8f',
+          lowerTick: -1000,
+          upperTick: 32000,
+          tokenAmount: 0.5e6,
+          isCoinA: true,
+          maxAmountTokenA: 0.5e6,
+          maxAmountTokenB: 0.5e6,
+        },
+        testWallet,
+        "sui:mainnet"
+      );
   
-      expect(JSON.stringify(data)).toBe(`{"txType":"Other","txSubType":"OpenAndAddLiquidity","intentionData":{"pool":"0x03db251ba509a8d5d8777b6338836082335d93eecbdd09a11e190a1cff51c352","lowerTick":-55760,"upperTick":-55320,"tokenAmount":100000000,"maxAmountTokenA":100000000,"maxAmountTokenB":0,"isTokenAFixed":true}}`);
+      const data = await helper.deserialize({transaction} as any);
+  
+      expect(JSON.stringify(data)).toBe(`{"txType":"Other","txSubType":"OpenAndAddLiquidity","intentionData":{"pool":"0x0321b68a0fca8c990710d26986ba433d06b351deba9384017cd6175f20466a8f","lowerTick":-1000,"upperTick":32000,"tokenAmount":"500000","maxAmountTokenA":"500000","maxAmountTokenB":"500000","isTokenAFixed":true}}`);
 
     })
 
@@ -648,11 +170,11 @@ describe('Bluefin App', () => {
 
     const helper = new BluefinHelper();
 
-    let ts: TestSuiteLegacy<BluefinIntentionData>;
+    let ts: TestSuite<BluefinIntentionData>;
 
 
     beforeEach(() => {
-      ts = new TestSuiteLegacy(testWallet, 'sui:mainnet', helper);
+      ts = new TestSuite(testWallet, 'sui:mainnet', helper);
     });
 
     it('build open position and provide liquidity transaction', async () => {
@@ -678,8 +200,8 @@ describe('Bluefin App', () => {
       const txb = await ts.voteAndExecuteIntention();
 
       expect(txb).toBeDefined();
-      expect(txb.txb.blockData.sender).toBe(testWallet.address);
-      expect(txb.txb.blockData.version).toBe(1);
+      expect(txb.tx.blockData.sender).toBe(testWallet.address);
+      expect(txb.tx.blockData.version).toBe(1);
 
     });
   });


### PR DESCRIPTION
- Reverting back the legacy sui changes.
- Our SDK is now configured to generate `Transaction` from `@mysten/sui` instead of `TransactionBlock` from `@mysten/sui.js` package.
- Also, instead of `signAndExecute`, we now just `sign` the tx and let the wallet take care of execution part on UI.
- The `deserialize()` method in `BluefinHelper` is now expected to receive `Transaction` which it should be able to deserialize perfectly after reverting the legacy changes. 
 
Reverts Momentum-Safe/msafe-sui-app-store#149