### PR TITLE
Bluefin - Fixed ObjectId of undefined Issue

### DIFF
--- a/src/apps/bluefin/decoder.ts
+++ b/src/apps/bluefin/decoder.ts
@@ -27,7 +27,7 @@ export class Decoder {
       txType: TransactionType.Other,
       type: TransactionSubType.OpenAndAddLiquidity,
       intentionData: {
-        pool: this.getObjectID(this.getInputIndex(openPosCommand, 1)),
+        pool: this.getSharedObjectID(this.getInputIndex(openPosCommand, 1)),
         lowerTick: Number(asIntN(BigInt(this.getU32(this.getInputIndex(openPosCommand, 2)))).toString()),
         upperTick: Number(asIntN(BigInt(this.getU32(this.getInputIndex(openPosCommand, 3)))).toString()),
         tokenAmount: this.getU64(this.getInputIndex(addLiqCommand, 6)),
@@ -54,8 +54,12 @@ export class Decoder {
     return this.commands.find((command) => command.$kind === 'MoveCall' && command.MoveCall.function === fn);
   }
 
-  private getObjectID(index: number): string {
-    return this.inputs[index].UnresolvedObject.objectId as string;
+  private getSharedObjectID(index: number): string {
+    return this.inputs[index].Object.SharedObject.objectId as string;
+  }
+
+  private getOwnedObjectID(index: number): string {
+    return this.inputs[index].Object.ImmOrOwnedObject.objectId as string;
   }
 
   private getU32(index: number): string {

--- a/src/apps/bluefin/tx-builder.ts
+++ b/src/apps/bluefin/tx-builder.ts
@@ -23,7 +23,7 @@ export default class TxBuilder {
       txbParams.lowerTick,
       txbParams.upperTick,
       res,
-      { returnTx: true },
+      { returnTx: true, sender: account.address },
     )) as any as Transaction;
 
     return txb;


### PR DESCRIPTION
## Description

During unit tests, the transaction being passed to `deserialize` method was not `built` and thus the inputs contained "Unresolved" objects. The decoder was written to handle the unresolved objects. But when using the app through msafe wallet, the tx gets built and signed which resolves these objects that changes the structure of the input that was causing a property of undefined being read. The PR fixed the issue.
