### PR TITLE
Bluefin - Added Action/TxbParams to intention data

### DIFF
--- a/src/apps/bluefin/decoder.ts
+++ b/src/apps/bluefin/decoder.ts
@@ -4,7 +4,7 @@ import { fromB64 } from '@mysten/bcs';
 import { bcs } from '@mysten/sui/bcs';
 import { Transaction } from '@mysten/sui/transactions';
 
-import { DecodeResult, TransactionSubType } from './types';
+import { BluefinIntentionData, DecodeResult, TransactionSubType } from './types';
 
 export class Decoder {
   constructor(public readonly transaction: Transaction) {}
@@ -37,7 +37,7 @@ export class Decoder {
           isTokenAFixed: this.getBoolean(this.getInputIndex(addLiqCommand, 9)),
         },
         action: TransactionSubType.OpenAndAddLiquidity,
-      },
+      } as BluefinIntentionData,
     };
   }
 

--- a/src/apps/bluefin/decoder.ts
+++ b/src/apps/bluefin/decoder.ts
@@ -27,13 +27,16 @@ export class Decoder {
       txType: TransactionType.Other,
       type: TransactionSubType.OpenAndAddLiquidity,
       intentionData: {
-        pool: this.getSharedObjectID(this.getInputIndex(openPosCommand, 1)),
-        lowerTick: Number(asIntN(BigInt(this.getU32(this.getInputIndex(openPosCommand, 2)))).toString()),
-        upperTick: Number(asIntN(BigInt(this.getU32(this.getInputIndex(openPosCommand, 3)))).toString()),
-        tokenAmount: this.getU64(this.getInputIndex(addLiqCommand, 6)),
-        maxAmountTokenA: this.getU64(this.getInputIndex(addLiqCommand, 7)),
-        maxAmountTokenB: this.getU64(this.getInputIndex(addLiqCommand, 8)),
-        isTokenAFixed: this.getBoolean(this.getInputIndex(addLiqCommand, 9)),
+        txbParams: {
+          pool: this.getSharedObjectID(this.getInputIndex(openPosCommand, 1)),
+          lowerTick: Number(asIntN(BigInt(this.getU32(this.getInputIndex(openPosCommand, 2)))).toString()),
+          upperTick: Number(asIntN(BigInt(this.getU32(this.getInputIndex(openPosCommand, 3)))).toString()),
+          tokenAmount: this.getU64(this.getInputIndex(addLiqCommand, 6)),
+          maxAmountTokenA: this.getU64(this.getInputIndex(addLiqCommand, 7)),
+          maxAmountTokenB: this.getU64(this.getInputIndex(addLiqCommand, 8)),
+          isTokenAFixed: this.getBoolean(this.getInputIndex(addLiqCommand, 9)),
+        },
+        action: TransactionSubType.OpenAndAddLiquidity,
       },
     };
   }

--- a/src/apps/bluefin/helper.ts
+++ b/src/apps/bluefin/helper.ts
@@ -61,6 +61,7 @@ export class BluefinHelper implements IAppHelperInternal<BluefinIntentionData> {
   }): Promise<Transaction> {
     const { suiClient, account, network } = input;
 
+    console.log(input.txSubType);
     let intention: BluefinIntention;
     switch (input.txSubType) {
       case TransactionSubType.OpenAndAddLiquidity:

--- a/src/apps/bluefin/intentions/open-position-with-liquidity.ts
+++ b/src/apps/bluefin/intentions/open-position-with-liquidity.ts
@@ -20,6 +20,7 @@ export class OpenAndAddLiquidity extends BaseIntention<BluefinIntentionData> {
   async build(input: { network: SuiNetworks; suiClient: SuiClient; account: WalletAccount }): Promise<Transaction> {
     const { account, network } = input;
     const { txbParams } = this.data;
+    console.log(txbParams);
     const txb = await TxBuilder.openPositionAndAddLiquidity(txbParams, account, network);
     return txb;
   }


### PR DESCRIPTION
## Description

- The intention data of `OpenPositionAndAddLiquidity` was missing `action` and `txbParams`, causing `build` to fail.
- Added more logs
