### PR TITLE
chore: change suilend dependencies to deps instead to peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,9 @@
     "@mysten/sui": "^1.8.0",
     "@open-rpc/client-js": "^1.8.1",
     "@pythnetwork/pyth-sui-js": "^2.1.0",
+    "@suilend/frontend-sui": "^0.2.35",
+    "@suilend/sdk": "^1.1.36",
+    "@suilend/springsui-sdk": "^1.0.17",
     "axios": "^1.6.7",
     "bignumber.js": "^9.1.2",
     "bucket-protocol-sdk": "^0.10.17",
@@ -92,9 +95,6 @@
   "peerDependencies": {
     "@msafe/sui3-utils": ">3.0.0",
     "@mysten/sui.js": ">0.50.0",
-    "@mysten/wallet-standard": ">0.11.0",
-    "@suilend/frontend-sui": "^0.2.33",
-    "@suilend/sdk": "^1.1.36",
-    "@suilend/springsui-sdk": "^1.0.17"
+    "@mysten/wallet-standard": ">0.11.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3719,7 +3719,19 @@
     mixpanel-browser "^2.56.0"
     next "^15.0.3"
 
-"@suilend/sdk@^1.1.24":
+"@suilend/frontend-sui@^0.2.35":
+  version "0.2.35"
+  resolved "https://registry.yarnpkg.com/@suilend/frontend-sui/-/frontend-sui-0.2.35.tgz#29f5bf01e8934976640f9baf51ded9639ac9240f"
+  integrity sha512-pUFb3AyodZFfhIKo5fE4E52lOxaxGg+aiMB09gaYDIPf81W+vfTqhrnSPmumIfoYCVhyEx3U4LrPHFYlHJ525A==
+  dependencies:
+    "@mysten/sui" "1.20.0"
+    "@pythnetwork/pyth-sui-js" "^2.1.0"
+    bignumber.js "^9.1.2"
+    lodash "^4.17.21"
+    mixpanel-browser "^2.56.0"
+    next "^15.0.3"
+
+"@suilend/sdk@^1.1.24", "@suilend/sdk@^1.1.36":
   version "1.1.36"
   resolved "https://registry.yarnpkg.com/@suilend/sdk/-/sdk-1.1.36.tgz#2429bd7d38c34c70a6b64985b2f5bbe388bc435d"
   integrity sha512-mhofvhfiq+3ImIxQ9cGEIytiTjtp0SrswIHtimBkXGfMU/ZMBSd65dtdDlh4A8+AMayQI4S8SkLniyztHod6uA==
@@ -3732,7 +3744,7 @@
     p-limit "3.1.0"
     uuid "^11.0.3"
 
-"@suilend/springsui-sdk@^1.0.12":
+"@suilend/springsui-sdk@^1.0.12", "@suilend/springsui-sdk@^1.0.17":
   version "1.0.17"
   resolved "https://registry.yarnpkg.com/@suilend/springsui-sdk/-/springsui-sdk-1.0.17.tgz#1fcb7a567659f04dc9597b000699e23cdcb7de24"
   integrity sha512-aJ/Qj6rLOfYC8dmnhtwu6+Km1ThBndjHYJJ+dPilXnMqXWE9jBR23k/m6DVBAPWmR0IOdfotyb32tXKXIS9w2A==
@@ -8744,7 +8756,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8808,7 +8829,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -9439,7 +9467,16 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## Description

Change suilend peer deps to deps

### TODO

Current unit test have issue from sprintsui:

```
Argument of type 'import("/Users/yanxiangwang/Workspace/github/Momentum-Safe/msafe-sui-app-store/node_modules/@mysten/sui/dist/cjs/client/client").SuiClient' is not assignable to parameter of type 'import("/Users/yanxiangwang/Workspace/github/Momentum-Safe/msafe-sui-app-store/node_modules/@suilend/springsui-sdk/node_modules/@mysten/sui/dist/cjs/client/client").SuiClient'.
      Property 'transport' is protected but type 'SuiClient' is not a class derived from 'SuiClient'.
```

Waiting the dep issue to be resolved from suilend. 


