### PR TITLE
fix: update @mysten/bcs import and version changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@cetusprotocol/cetus-xcetus-sdk": "^0.1.1",
     "@cetusprotocol/vaults-sdk": "^0.1.15",
     "@firefly-exchange/library-sui": "^2.4.18",
-    "@mysten/bcs": "^0.11.1",
+    "@mysten/bcs": "^1.5.0",
     "@mysten/sui": "^1.8.0",
     "@open-rpc/client-js": "^1.8.1",
     "@pythnetwork/pyth-sui-js": "^2.1.0",

--- a/src/apps/alphafi/decoder.ts
+++ b/src/apps/alphafi/decoder.ts
@@ -1,6 +1,6 @@
 import { coinsList, poolIdPoolNameMap, poolInfo, PoolName, singleAssetPoolCoinMap } from '@alphafi/alphafi-sdk';
 import { TransactionType } from '@msafe/sui3-utils';
-import { bcs, fromB64 } from '@mysten/bcs';
+import { bcs, fromBase64 } from '@mysten/bcs';
 import { DevInspectResults } from '@mysten/sui/client';
 import { Transaction } from '@mysten/sui/transactions';
 
@@ -120,13 +120,13 @@ export class Decoder {
 
     let res;
     if (bytes.length === 12) {
-      res = bcs.u64().parse(fromB64(bytes));
+      res = bcs.u64().parse(fromBase64(bytes));
     } else if (bytes.length === 24) {
-      res = bcs.u128().parse(fromB64(bytes));
+      res = bcs.u128().parse(fromBase64(bytes));
     } else if (bytes.length === 44) {
-      res = bcs.u256().parse(fromB64(bytes));
+      res = bcs.u256().parse(fromBase64(bytes));
     } else {
-      res = bcs.u64().parse(fromB64(bytes));
+      res = bcs.u64().parse(fromBase64(bytes));
     }
 
     return res;

--- a/src/apps/bluefin/decoder.ts
+++ b/src/apps/bluefin/decoder.ts
@@ -1,6 +1,6 @@
 import { asIntN } from '@cetusprotocol/cetus-sui-clmm-sdk';
 import { TransactionType } from '@msafe/sui3-utils';
-import { fromB64 } from '@mysten/bcs';
+import { fromBase64 } from '@mysten/bcs';
 import { bcs } from '@mysten/sui/bcs';
 import { Transaction } from '@mysten/sui/transactions';
 
@@ -235,23 +235,23 @@ export class Decoder {
   }
 
   private getU32(index: number): string {
-    return String(bcs.u32().parse(Uint8Array.from(fromB64(this.inputs[index].Pure.bytes))));
+    return String(bcs.u32().parse(Uint8Array.from(fromBase64(this.inputs[index].Pure.bytes))));
   }
 
   private getU64(index: number): string {
-    return bcs.u64().parse(Uint8Array.from(fromB64(this.inputs[index].Pure.bytes)));
+    return bcs.u64().parse(Uint8Array.from(fromBase64(this.inputs[index].Pure.bytes)));
   }
 
   private getU128(index: number): string {
-    return bcs.u128().parse(Uint8Array.from(fromB64(this.inputs[index].Pure.bytes)));
+    return bcs.u128().parse(Uint8Array.from(fromBase64(this.inputs[index].Pure.bytes)));
   }
 
   private getBoolean(index: number): boolean {
-    return bcs.bool().parse(Uint8Array.from(fromB64(this.inputs[index].Pure.bytes)));
+    return bcs.bool().parse(Uint8Array.from(fromBase64(this.inputs[index].Pure.bytes)));
   }
 
   private getAddress(index: number): string {
-    return bcs.Address.parse(Uint8Array.from(fromB64(this.inputs[index].Pure.bytes)));
+    return bcs.Address.parse(Uint8Array.from(fromBase64(this.inputs[index].Pure.bytes)));
   }
 
   private getTypeArguments(command: any): Array<string> {

--- a/src/apps/plain-transaction/helper.ts
+++ b/src/apps/plain-transaction/helper.ts
@@ -1,5 +1,5 @@
 import { TransactionSubTypes, TransactionType } from '@msafe/sui3-utils';
-import { fromHEX } from '@mysten/bcs';
+import { fromHex } from '@mysten/bcs';
 import { SuiClient } from '@mysten/sui/client';
 import { Transaction } from '@mysten/sui/transactions';
 import { IdentifierString, WalletAccount } from '@mysten/wallet-standard';
@@ -30,7 +30,7 @@ export class PlainTransactionIntention implements TransactionIntention<PlainTran
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async build(input: { suiClient: SuiClient; account: WalletAccount; network: SuiNetworks }): Promise<Transaction> {
-    return Transaction.from(fromHEX(this.data.content));
+    return Transaction.from(fromHex(this.data.content));
   }
 
   static fromData(data: PlainTransactionData) {

--- a/src/apps/suilend/decoder.ts
+++ b/src/apps/suilend/decoder.ts
@@ -1,5 +1,5 @@
 import { TransactionType } from '@msafe/sui3-utils';
-import { fromB64, toHEX } from '@mysten/bcs';
+import { fromBase64, toHex } from '@mysten/bcs';
 import { DevInspectResults } from '@mysten/sui/client';
 import { Transaction } from '@mysten/sui/transactions';
 import { normalizeStructTag } from '@mysten/sui/utils';
@@ -139,7 +139,7 @@ export class Decoder {
     console.log('Decoder.decodeWithdraw', coinType, value);
 
     const inputIndex = (commands.withdraw_ctokens.MoveCall.arguments[4] as any).Input as number;
-    const inputValue = new BigNumber(toHEX(fromB64(this.inputs[inputIndex].Pure!.bytes)), 16).toString();
+    const inputValue = new BigNumber(toHex(fromBase64(this.inputs[inputIndex].Pure!.bytes)), 16).toString();
 
     const isMax = inputValue === MAX_U64.toString();
     console.log(
@@ -179,7 +179,7 @@ export class Decoder {
     console.log('Decoder.decodeBorrow', coinType, value);
 
     const inputIndex = (commands.borrow_request.MoveCall.arguments[4] as any).Input as number;
-    const inputValue = new BigNumber(toHEX(fromB64(this.inputs[inputIndex].Pure!.bytes)), 16).toString();
+    const inputValue = new BigNumber(toHex(fromBase64(this.inputs[inputIndex].Pure!.bytes)), 16).toString();
 
     const isMax = inputValue === MAX_U64.toString();
     console.log(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2889,7 +2889,7 @@
   dependencies:
     bs58 "^6.0.0"
 
-"@mysten/bcs@1.5.0":
+"@mysten/bcs@1.5.0", "@mysten/bcs@^1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@mysten/bcs/-/bcs-1.5.0.tgz#ed8f96c5577a391dcfe8a0945db828e3531cc0a1"
   integrity sha512-v39dm5oNfKYMAf2CVI+L0OaJiG9RVXsjqPM4BwTKcHNCZOvr35IIewGtXtWXsI67SQU2TRq8lhQzeibdiC/CNg==
@@ -9649,7 +9649,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -9706,7 +9715,14 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -10461,7 +10477,16 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
- Update @mysten/bcs version to 1.5.0 in package.json
- Change fromB64 to fromBase64 in multiple decoder files
- Update fromHEX to fromHex in helper.ts
- Adjust imports in various decoder files for consistency

## Description

One line of brief description of what changes have been made in this PR.
Add links to the issue / bug report if necessary.

* Use bullet points for detailed changes.
* Each bullet point shall be a feature.
