### PR TITLE
Migrate from deprecated `blockData`

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
         "@nemoprotocol/vaults-sdk": "^0.2.4",
         "@open-rpc/client-js": "^1.8.1",
         "@pythnetwork/pyth-sui-js": "^2.1.0",
-        "@scallop-io/sui-scallop-sdk": "^2.1.6",
+        "@scallop-io/sui-scallop-sdk": "^2.4.4",
         "@suilend/sdk": "^1.1.57",
         "@suilend/springsui-sdk": "^1.0.24",
         "@suilend/sui-fe": "^0.2.72",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@msafe/sui-app-store",
-  "version": "0.0.335",
+  "version": "0.0.336",
   "description": "MSafe Sui app store repository",
   "author": "Momentum Safe",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@msafe/sui-app-store",
-  "version": "0.0.336",
+  "version": "0.0.337",
   "description": "MSafe Sui app store repository",
   "author": "Momentum Safe",
   "license": "MIT",

--- a/src/apps/scallop/decoders/decoderLending.ts
+++ b/src/apps/scallop/decoders/decoderLending.ts
@@ -149,7 +149,10 @@ export class DecoderLending extends Decoder {
   }
 
   private isOpenObligationTransaction() {
-    return this.hasMoveCallCommand(`${this.coreId.protocolPkg}::open_obligation::open_obligation`);
+    return (
+      this.hasMoveCallCommand(`${this.coreId.protocolPkg}::open_obligation::open_obligation`) ||
+      this.hasMoveCallCommand(`${this.coreId.protocolPkg}::open_obligation::open_obligation_entry`)
+    );
   }
 
   private isMigrateAndClaim() {

--- a/src/apps/scallop/decoders/decoderReferral.ts
+++ b/src/apps/scallop/decoders/decoderReferral.ts
@@ -60,7 +60,8 @@ export class DecoderReferral extends Decoder {
 
   private decodeClaimRevenueReferral(): DecodeResult {
     const veScaKey = this.helperClaimRevenueReferral[0].decodeOwnedObjectId(2);
-    const coins = this.helperClaimRevenueReferral.map((helper) => helper.typeArg(0));
+    // typeArg(0) is the full coin type; intentionData uses coin names.
+    const coins = this.helperClaimRevenueReferral.map((helper) => this.utils.parseCoinNameFromType(helper.typeArg(0)));
     return {
       txType: TransactionType.Other,
       type: TransactionSubType.ClaimRevenueReferral,

--- a/src/apps/scallop/helper.ts
+++ b/src/apps/scallop/helper.ts
@@ -1,5 +1,5 @@
 import { TransactionType } from '@msafe/sui3-utils';
-import { getFullnodeUrl, SuiClient } from '@mysten/sui/client';
+import { SuiClient } from '@mysten/sui/client';
 import { Transaction } from '@mysten/sui/transactions';
 import { IdentifierString, WalletAccount } from '@mysten/wallet-standard';
 import { Scallop, ScallopClient } from '@scallop-io/sui-scallop-sdk';
@@ -138,9 +138,6 @@ export class ScallopAppHelper implements IAppHelperInternal<ScallopIntentionData
         addressId: '695fcdc084f790c04eb068dc',
         walletAddress,
         suiClients: [suiClient],
-        fullnodeUrls: [
-          (suiClient as any).transport.rpcClient.requestManager.transports[0]?.uri ?? getFullnodeUrl('mainnet'),
-        ],
       });
       this.scallopClient = await scallop.createScallopClient();
     }

--- a/src/apps/scallop/intentions/referral/claim-revenue-referral.ts
+++ b/src/apps/scallop/intentions/referral/claim-revenue-referral.ts
@@ -35,9 +35,8 @@ export class ClaimRevenueReferralIntention extends ScallopCoreBaseIntention<Clai
     const tx = client.builder.createTxBlock();
     tx.setSender(sender);
 
-    const coinsName = coins.map((coin) => client.utils.parseCoinNameFromType(coin));
-
-    await tx.claimReferralRevenueQuick(veScaKey, coinsName);
+    // `coins` are already coin names (e.g. 'usdc'); claimReferralRevenueQuick expects names.
+    await tx.claimReferralRevenueQuick(veScaKey, coins);
     return tx.txBlock;
   }
 

--- a/src/apps/scallop/intentions/staking/split-ve-sca.ts
+++ b/src/apps/scallop/intentions/staking/split-ve-sca.ts
@@ -15,7 +15,7 @@ export interface SplitVeScaIntentionData {
 export class SplitVeScaIntention extends ScallopCoreBaseIntention<SplitVeScaIntentionData> {
   txType: TransactionType.Other;
 
-  txSubType: TransactionSubType.MergeVeSca;
+  txSubType: TransactionSubType.SplitVeSca;
 
   constructor(public readonly data: SplitVeScaIntentionData) {
     super(data);

--- a/src/apps/scallop/intentions/staking/ve-sca-transfers.ts
+++ b/src/apps/scallop/intentions/staking/ve-sca-transfers.ts
@@ -18,7 +18,7 @@ export interface TransferVeScaKeysIntentionData {
 export class TransferVeScaKeysIntention extends ScallopCoreBaseIntention<TransferVeScaKeysIntentionData> {
   txType: TransactionType.Other;
 
-  txSubType: TransactionSubType.MergeVeSca;
+  txSubType: TransactionSubType.TransferVeScaKeys;
 
   constructor(public readonly data: TransferVeScaKeysIntentionData) {
     super(data);

--- a/src/apps/scallop/types/sui.ts
+++ b/src/apps/scallop/types/sui.ts
@@ -1,17 +1,20 @@
-import { Transaction } from '@mysten/sui/transactions';
+import { TransactionData } from '@mysten/sui/transactions';
 
-type GetDataReturnType = ReturnType<Transaction['getData']>;
-export type TransactionInputs = GetDataReturnType['inputs'];
-export type TransactionCommands = GetDataReturnType['commands'];
+export type TransactionInputs = TransactionData['inputs'];
+export type TransactionCommands = TransactionData['commands'];
 export type TransactionCommand = TransactionCommands[number];
+export type TransactionCommandKind = TransactionCommand['$kind'];
 
 export type TransferObjectsCommand = TransactionCommand['TransferObjects'];
 export type MoveCallCommand = TransactionCommand['MoveCall'];
 export type SplitCoinCommand = TransactionCommand['SplitCoins'];
 
-export type TxBlockTransactionType = Transaction['blockData']['transactions'][number];
-export type MoveCallTransactionType = TxBlockTransactionType & { kind: 'MoveCall' };
-export type SplitCoinTransactionType = TxBlockTransactionType & { kind: 'SplitCoins' };
-export type MoveCallTransactionArgumentType = MoveCallTransactionType['arguments'][number];
+// A single resolved input (CallArg) from getData().inputs.
+export type TransactionInput = TransactionInputs[number];
+// Full command variants (replace the deprecated blockData-based aliases).
+export type MoveCallTransactionType = Extract<TransactionCommand, { $kind: 'MoveCall' }>;
+export type SplitCoinTransactionType = Extract<TransactionCommand, { $kind: 'SplitCoins' }>;
+// A single argument reference of a MoveCall command.
+export type MoveCallTransactionArgumentType = NonNullable<MoveCallCommand>['arguments'][number];
 
 export type BcsType = 'U8' | 'U16' | 'U32' | 'U64' | 'U128' | 'U256' | 'Address' | 'String' | 'Bool';

--- a/src/apps/scallop/utils/moveCallHelper.ts
+++ b/src/apps/scallop/utils/moveCallHelper.ts
@@ -1,15 +1,8 @@
 import { bcs } from '@mysten/sui/bcs';
 import { Transaction } from '@mysten/sui/transactions';
-import { normalizeStructTag, normalizeSuiAddress } from '@mysten/sui/utils';
-import { TransactionBlockInput } from '@mysten/sui.js/transactions';
+import { fromBase64, normalizeStructTag, normalizeSuiAddress } from '@mysten/sui/utils';
 
-import {
-  BcsType,
-  MoveCallTransactionArgumentType,
-  MoveCallTransactionType,
-  SplitCoinTransactionType,
-  TransactionCommand,
-} from '../types/sui';
+import { BcsType, TransactionCommand, TransactionCommandKind, TransactionInput } from '../types/sui.js';
 
 class MoveCallHelper {
   private cmdIdx: number;
@@ -21,7 +14,7 @@ class MoveCallHelper {
   ) {
     const indexes: number[] = [];
     if (moveCall?.MoveCall) {
-      transaction.getData().commands.filter((t, idx) => {
+      this.transaction.getData().commands.filter((t, idx) => {
         if (t.$kind === 'MoveCall') {
           const target = `${t.MoveCall.package}::${t.MoveCall.module}::${t.MoveCall.function}`;
           const moveCallTarget = `${moveCall.MoveCall.package}::${moveCall.MoveCall.module}::${moveCall.MoveCall.function}`;
@@ -38,8 +31,13 @@ class MoveCallHelper {
     this.cmdIdx = indexes[index];
   }
 
-  get txBlockTransactions(): MoveCallTransactionType {
-    return this.transaction.blockData.transactions[this.cmdIdx] as MoveCallTransactionType;
+  getTransaction<Kind extends TransactionCommandKind>(idx: number): Extract<TransactionCommand, { $kind: Kind }> {
+    return this.transaction.getData().commands[idx] as Extract<TransactionCommand, { $kind: Kind }>;
+  }
+
+  // MoveCall payload at the matched command index ({ package, module, function, typeArguments, arguments }).
+  get txBlockTransactions() {
+    return this.getTransaction<'MoveCall'>(this.cmdIdx).MoveCall;
   }
 
   decodeSharedObjectId(argIndex: number) {
@@ -80,72 +78,64 @@ class MoveCallHelper {
     return MoveCallHelper.getPureInputValue<T>(input, type);
   }
 
-  getInputParam(argIndex: number) {
-    const arg = this.txBlockTransactions.arguments[argIndex] as MoveCallTransactionArgumentType;
-    if (arg.kind !== 'Input') {
+  // Resolve the argument at argIndex to its underlying input (CallArg) in getData().inputs.
+  getInputParam(argIndex: number): TransactionInput {
+    const arg = this.txBlockTransactions.arguments[argIndex];
+    if (arg.$kind !== 'Input') {
       throw new Error('not input type');
     }
-    return arg;
+    return this.transaction.getData().inputs[arg.Input];
   }
 
-  getNestedInputParam<T = SplitCoinTransactionType>(argIndex: number) {
-    const arg = this.txBlockTransactions.arguments[argIndex] as MoveCallTransactionArgumentType;
-    if (arg.kind !== 'NestedResult' && arg.kind !== 'Result') {
+  // Resolve a Result/NestedResult argument to the command that produced it.
+  getNestedInputParam<T>(argIndex: number): T {
+    const arg = this.txBlockTransactions.arguments[argIndex];
+    if (arg.$kind !== 'NestedResult' && arg.$kind !== 'Result') {
       throw new Error('not nested or result type');
     }
-    return this.transaction.blockData.transactions[arg.index] as T;
+    const commandIdx = arg.$kind === 'Result' ? arg.Result : arg.NestedResult[0];
+    return this.getTransaction(commandIdx) as unknown as T;
   }
 
-  static getPureInputValue<T>(input: TransactionBlockInput, type: BcsType) {
-    if (input.type !== 'pure') {
+  static getPureInputValue<T>(input: TransactionInput, type: BcsType) {
+    if (input.$kind !== 'Pure') {
       throw new Error('not pure argument');
     }
-    if (typeof input.value === 'object' && 'Pure' in input.value) {
-      const bcsNums = input.value.Pure;
-      const a = bcs[type];
-      return bcs[type].parse(new Uint8Array(bcsNums)) as T;
-    }
-    return input.value as T;
+    return bcs[type].parse(fromBase64(input.Pure.bytes)) as T;
   }
 
-  static getOwnedObjectId(input: TransactionBlockInput) {
-    if (input.type !== 'object') {
+  static getOwnedObjectId(input: TransactionInput) {
+    // A client-built (unresolved) tx carries object refs as UnresolvedObject with just the id.
+    if (input.$kind === 'UnresolvedObject') {
+      return normalizeSuiAddress(input.UnresolvedObject.objectId);
+    }
+    if (input.$kind !== 'Object') {
       throw new Error(`not object argument: ${JSON.stringify(input)}`);
     }
-    if (typeof input.value === 'object') {
-      if (!('Object' in input.value) || !('ImmOrOwned' in input.value.Object)) {
-        throw new Error('not ImmOrOwned');
-      }
-      return normalizeSuiAddress(input.value.Object.ImmOrOwned.objectId as string);
+    if (input.Object.$kind !== 'ImmOrOwnedObject') {
+      throw new Error('not ImmOrOwned');
     }
-    return normalizeSuiAddress(input.value as string);
+    return normalizeSuiAddress(input.Object.ImmOrOwnedObject.objectId);
   }
 
-  static getSharedObjectId(input: TransactionBlockInput) {
-    if (input.type !== 'object') {
+  static getSharedObjectId(input: TransactionInput) {
+    if (input.$kind === 'UnresolvedObject') {
+      return normalizeSuiAddress(input.UnresolvedObject.objectId);
+    }
+    if (input.$kind !== 'Object') {
       throw new Error(`not object argument: ${JSON.stringify(input)}`);
     }
-    if (typeof input.value !== 'object') {
-      return normalizeSuiAddress(input.value as string);
-    }
-    if (!('Object' in input.value) || !('Shared' in input.value.Object)) {
+    if (input.Object.$kind !== 'SharedObject') {
       throw new Error('not Shared');
     }
-    return normalizeSuiAddress(input.value.Object.Shared.objectId as string);
+    return normalizeSuiAddress(input.Object.SharedObject.objectId);
   }
 
-  static getPureInput<T>(input: TransactionBlockInput) {
-    if (input.type !== 'pure') {
+  static getPureInput<T>(input: TransactionInput, type: BcsType = 'U64') {
+    if (input.$kind !== 'Pure') {
       throw new Error('not pure argument');
     }
-    if (typeof input.value !== 'object') {
-      return input.value as T;
-    }
-    if (!('Pure' in input.value)) {
-      throw new Error('Pure not in value');
-    }
-    const bcsVal = input.value.Pure;
-    return bcs.U64.parse(new Uint8Array(bcsVal)) as T;
+    return bcs[type].parse(fromBase64(input.Pure.bytes)) as T;
   }
 
   typeArg(index: number) {
@@ -153,7 +143,7 @@ class MoveCallHelper {
   }
 
   txArg(index: number) {
-    return this.transaction.blockData.inputs[index];
+    return this.transaction.getData().inputs[index];
   }
 }
 

--- a/src/apps/scallop/utils/splitCoinHelper.ts
+++ b/src/apps/scallop/utils/splitCoinHelper.ts
@@ -10,14 +10,15 @@ class SplitCoinHelper {
   ) {}
 
   getAmountInput() {
-    return this.splitCoin.amounts
-      .map((input) => {
-        if (input.kind === 'Input') {
+    return this.splitCoin.SplitCoins.amounts
+      .map((arg) => {
+        if (arg.$kind === 'Input') {
+          const input = this.txb.getData().inputs[arg.Input];
           return Number(MoveCallHelper.getPureInputValue<number>(input, 'U64'));
         }
         return undefined;
       })
-      .filter((input) => input !== undefined);
+      .filter((amount): amount is number => amount !== undefined);
   }
 }
 

--- a/test/scallop.config.ts
+++ b/test/scallop.config.ts
@@ -1,8 +1,9 @@
-import { ScallopAppHelper } from '@/apps/scallop/helper';
 import { HexToUint8Array } from '@msafe/sui3-utils';
 import { getFullnodeUrl, SuiClient } from '@mysten/sui/client';
 import { SUI_MAINNET_CHAIN, WalletAccount } from '@mysten/wallet-standard';
 import { ScallopClient } from '@scallop-io/sui-scallop-sdk';
+
+import { ScallopAppHelper } from '@/apps/scallop/helper';
 
 export const client = new SuiClient({ url: getFullnodeUrl('mainnet') });
 export const account: WalletAccount = {
@@ -31,6 +32,7 @@ export const accountWithSusdc: WalletAccount = {
 };
 
 export const helper = new ScallopAppHelper();
+
 export const scallopClient = new ScallopClient({
   addressId: '695fcdc084f790c04eb068dc',
 });

--- a/test/scallop.config.ts
+++ b/test/scallop.config.ts
@@ -1,9 +1,11 @@
+import { ScallopAppHelper } from '@/apps/scallop/helper';
 import { HexToUint8Array } from '@msafe/sui3-utils';
-import { getFullnodeUrl, SuiClient } from '@mysten/sui.js/client';
+import { getFullnodeUrl, SuiClient } from '@mysten/sui/client';
 import { SUI_MAINNET_CHAIN, WalletAccount } from '@mysten/wallet-standard';
+import { ScallopClient } from '@scallop-io/sui-scallop-sdk';
 
-export const Client = new SuiClient({ url: getFullnodeUrl('mainnet') });
-export const Account: WalletAccount = {
+export const client = new SuiClient({ url: getFullnodeUrl('mainnet') });
+export const account: WalletAccount = {
   address: '0x0367313b28fd88118bb4795ff2961028b2be594256074bba1a0052737d6db56b',
   publicKey: HexToUint8Array('0x0367313b28fd88118bb4795ff2961028b2be594256074bba1a0052737d6db56b'),
   chains: [SUI_MAINNET_CHAIN],
@@ -20,3 +22,15 @@ export const SpoolStakeAccount = {
 };
 
 export const vescaKey = '0x5e2c54651ca4e2352475e8419e3419cfcfe424af272ca59ae053e3c248c13c16';
+
+export const accountWithSusdc: WalletAccount = {
+  address: '0x61819c99588108d9f7710047e6ad8f2da598de8e98a26ea62bd7ad9847f5329c',
+  publicKey: HexToUint8Array('0x61819c99588108d9f7710047e6ad8f2da598de8e98a26ea62bd7ad9847f5329c'),
+  chains: [SUI_MAINNET_CHAIN],
+  features: [],
+};
+
+export const helper = new ScallopAppHelper();
+export const scallopClient = new ScallopClient({
+  addressId: '695fcdc084f790c04eb068dc',
+});

--- a/test/scallop.config.ts
+++ b/test/scallop.config.ts
@@ -22,7 +22,7 @@ export const SpoolStakeAccount = {
   susdc: '0x7ba3aae255483cdb6f0b733a63534de49c6883222e7b4a9ffc0be43d6737ed50',
 };
 
-export const vescaKey = '0x5e2c54651ca4e2352475e8419e3419cfcfe424af272ca59ae053e3c248c13c16';
+export const veScaKey = '0x5e2c54651ca4e2352475e8419e3419cfcfe424af272ca59ae053e3c248c13c16';
 
 export const accountWithSusdc: WalletAccount = {
   address: '0x61819c99588108d9f7710047e6ad8f2da598de8e98a26ea62bd7ad9847f5329c',

--- a/test/scallop.test.ts
+++ b/test/scallop.test.ts
@@ -31,7 +31,9 @@ const buildAndDeserialize = async (
 
 describe('Scallop App', () => {
   beforeEach(async () => {
-    if (initialized) return;
+    if (initialized) {
+      return;
+    }
     initialized = true;
     await scallopClient.init();
   });
@@ -241,7 +243,7 @@ describe('Scallop App', () => {
     expect(intention.serialize()).toBe(`{}`);
   });
 
-    it('Test Supply Lending intention deserialization', async () => {
+  it('Test Supply Lending intention deserialization', async () => {
     const intentionData = {
       amount: 1000,
       coinName: 'sui',

--- a/test/scallop.test.ts
+++ b/test/scallop.test.ts
@@ -15,9 +15,12 @@ import { ClaimRevenueReferralIntention } from '@/apps/scallop/intentions/referra
 import { CreateReferralLinkIntention } from '@/apps/scallop/intentions/referral/create-referral-link';
 import { ExtendPeriodAndStakeMoreIntention } from '@/apps/scallop/intentions/staking/extend-period-and-stake-more';
 import { ExtendStakePeriodIntention } from '@/apps/scallop/intentions/staking/extend-stake-period';
+import { SplitVeScaIntention } from '@/apps/scallop/intentions/staking/split-ve-sca';
+import { StakeScaIntention } from '@/apps/scallop/intentions/staking/stake-sca';
+import { VeScaObligationBindingsIntention } from '@/apps/scallop/intentions/staking/ve-sca-obligation-bindings';
 import { WithdrawStakedScaIntention } from '@/apps/scallop/intentions/staking/withdraw-staked-sca';
 
-import { account, accountWithSusdc, client, Obligation, vescaKey, helper, scallopClient } from './scallop.config';
+import { account, accountWithSusdc, client, Obligation, veScaKey, helper, scallopClient } from './scallop.config';
 
 let initialized = false;
 // Build the intention's transaction then round-trip it back through the decoder.
@@ -102,11 +105,11 @@ describe('Scallop App', () => {
       coinName: 'sui',
       obligationId: Obligation.obligationId,
       obligationKey: Obligation.obligationKey,
-      veScaKey: vescaKey,
+      veScaKey,
     });
 
     expect(intention.serialize()).toBe(
-      `{"amount":1000,"coinName":"sui","obligationId":"${Obligation.obligationId}","obligationKey":"${Obligation.obligationKey}","veScaKey":"${vescaKey}"}`,
+      `{"amount":1000,"coinName":"sui","obligationId":"${Obligation.obligationId}","obligationKey":"${Obligation.obligationKey}","veScaKey":"${veScaKey}"}`,
     );
   });
 
@@ -128,11 +131,11 @@ describe('Scallop App', () => {
       amount: 1000,
       coinName: 'sui',
       obligationId: Obligation.obligationId,
-      veScaKey: vescaKey,
+      veScaKey,
     });
 
     expect(intention.serialize()).toBe(
-      `{"amount":1000,"coinName":"sui","obligationId":"${Obligation.obligationId}","veScaKey":"${vescaKey}"}`,
+      `{"amount":1000,"coinName":"sui","obligationId":"${Obligation.obligationId}","veScaKey":"${veScaKey}"}`,
     );
   });
 
@@ -151,7 +154,7 @@ describe('Scallop App', () => {
   it('Test extend lock period intention serialization', () => {
     const intentionData = {
       unlockTime,
-      veScaKey: vescaKey,
+      veScaKey,
       obligationId: Obligation.obligationId,
       obligationKey: Obligation.obligationKey,
       isObligationLocked: true,
@@ -163,7 +166,7 @@ describe('Scallop App', () => {
     const parsed = JSON.parse(serialized);
 
     expect(parsed.unlockTime).toBe(unlockTime);
-    expect(parsed.veScaKey).toBe(vescaKey);
+    expect(parsed.veScaKey).toBe(veScaKey);
     expect(parsed.obligationId).toBe(Obligation.obligationId);
     expect(parsed.obligationKey).toBe(Obligation.obligationKey);
     expect(parsed.isObligationLocked).toBe(true);
@@ -176,7 +179,7 @@ describe('Scallop App', () => {
       unlockTime,
       obligationId: Obligation.obligationId,
       obligationKey: Obligation.obligationKey,
-      veScaKey: vescaKey,
+      veScaKey,
       isObligationLocked: true,
       isOldBorrowIncentive: false,
     });
@@ -188,7 +191,7 @@ describe('Scallop App', () => {
     expect(parsed.unlockTime).toBe(unlockTime);
     expect(parsed.obligationId).toBe(Obligation.obligationId);
     expect(parsed.obligationKey).toBe(Obligation.obligationKey);
-    expect(parsed.veScaKey).toBe(vescaKey);
+    expect(parsed.veScaKey).toBe(veScaKey);
     expect(parsed.isObligationLocked).toBe(true);
     expect(parsed.isOldBorrowIncentive).toBe(false);
   });
@@ -213,28 +216,53 @@ describe('Scallop App', () => {
       coinName: 'sui',
       obligationId: Obligation.obligationId,
       obligationKey: Obligation.obligationKey,
-      veScaKey: vescaKey,
+      veScaKey,
     });
 
     expect(intention.serialize()).toBe(
-      `{"amount":1000,"coinName":"sui","obligationId":"${Obligation.obligationId}","obligationKey":"${Obligation.obligationKey}","veScaKey":"${vescaKey}"}`,
+      `{"amount":1000,"coinName":"sui","obligationId":"${Obligation.obligationId}","obligationKey":"${Obligation.obligationKey}","veScaKey":"${veScaKey}"}`,
     );
+  });
+
+  it('Test stake sca intention serialization', () => {
+    const intention = StakeScaIntention.fromData({
+      amount: 10e9,
+      isObligationLocked: false,
+      isOldBorrowIncentive: false,
+      obligationId: Obligation.obligationId,
+      obligationKey: Obligation.obligationKey,
+      unlockTime,
+      veScaKey: undefined,
+    });
+
+    expect(intention.serialize()).toBe(
+      `{"amount":10000000000,"isObligationLocked":false,"isOldBorrowIncentive":false,"obligationId":"${Obligation.obligationId}","obligationKey":"${Obligation.obligationKey}","unlockTime":${unlockTime}}`,
+    );
+  });
+
+  it('Test Split VeSca serialization', () => {
+    const intention = SplitVeScaIntention.fromData({
+      splitAmount: 1e9,
+      targetVeScaKey: veScaKey,
+    });
+
+    expect(intention.serialize()).toBe(`{"splitAmount":1000000000,"targetVeScaKey":"${veScaKey}"}`);
   });
 
   it('Test Referral Bind Referral', () => {
     const intention = BindReferralIntention.fromData({
-      veScaKey: vescaKey,
+      veScaKey,
     });
 
-    expect(intention.serialize()).toBe(`{"veScaKey":"${vescaKey}"}`);
+    expect(intention.serialize()).toBe(`{"veScaKey":"${veScaKey}"}`);
   });
   it('Test Referral Claim Revenue', () => {
     const intention = ClaimRevenueReferralIntention.fromData({
-      veScaKey: vescaKey,
+      veScaKey,
       coins: ['usdt', 'usdc'],
     });
 
-    expect(intention.serialize()).toBe(`{"coins":["usdc","usdt"],"veScaKey":"${vescaKey}"}`);
+    expect(intention.serialize()).toBe(`{"coins":["usdc","usdt"],"veScaKey":"${veScaKey}"}`);
   });
 
   it('Test Create Referral Link', () => {
@@ -315,7 +343,7 @@ describe('Scallop App', () => {
       coinName: 'sui',
       obligationId: Obligation.obligationId,
       obligationKey: Obligation.obligationKey,
-      veScaKey: vescaKey,
+      veScaKey,
     };
     const d = await buildAndDeserialize(BorrowWithBoostIntention.fromData(intentionData));
     expect(d.txType).toBe('Other');
@@ -343,7 +371,7 @@ describe('Scallop App', () => {
       amount: 1000,
       coinName: 'sui',
       obligationId: Obligation.obligationId,
-      veScaKey: vescaKey,
+      veScaKey,
     };
     const d = await buildAndDeserialize(RepayWithBoostIntention.fromData(intentionData));
     expect(d.txType).toBe('Other');
@@ -371,7 +399,7 @@ describe('Scallop App', () => {
   it('Test extend lock period intention deserialization', async () => {
     const intentionData = {
       unlockTime,
-      veScaKey: vescaKey,
+      veScaKey,
       obligationId: Obligation.obligationId,
       obligationKey: Obligation.obligationKey,
       isObligationLocked: true,
@@ -390,7 +418,7 @@ describe('Scallop App', () => {
       unlockTime,
       obligationId: Obligation.obligationId,
       obligationKey: Obligation.obligationKey,
-      veScaKey: vescaKey,
+      veScaKey,
       isObligationLocked: true,
       isOldBorrowIncentive: false,
     };
@@ -420,7 +448,7 @@ describe('Scallop App', () => {
       coinName: 'sui',
       obligationId: Obligation.obligationId,
       obligationKey: Obligation.obligationKey,
-      veScaKey: vescaKey,
+      veScaKey,
     };
     const d = await buildAndDeserialize(BorrowWithReferralIntention.fromData(intentionData));
     expect(d.txType).toBe('Other');
@@ -429,7 +457,7 @@ describe('Scallop App', () => {
   });
 
   it('Test Referral Bind Referral deserialization', async () => {
-    const intentionData = { veScaKey: vescaKey };
+    const intentionData = { veScaKey };
     const d = await buildAndDeserialize(BindReferralIntention.fromData(intentionData));
     expect(d.txType).toBe('Other');
     expect(d.txSubType).toBe('BindReferral');
@@ -439,7 +467,7 @@ describe('Scallop App', () => {
   it('Test Referral Claim Revenue deserialization', async () => {
     // Use a single valid revenue coin: 'usdt' is not a claimable revenue coin (resolves to an empty type),
     // and multi-coin resolution is non-deterministic.
-    const intentionData = { veScaKey: vescaKey, coins: ['usdc'] };
+    const intentionData = { veScaKey, coins: ['usdc'] };
     const d = await buildAndDeserialize(ClaimRevenueReferralIntention.fromData(intentionData));
     expect(d.txType).toBe('Other');
     expect(d.txSubType).toBe('ClaimRevenueReferral');
@@ -451,6 +479,91 @@ describe('Scallop App', () => {
     const d = await buildAndDeserialize(CreateReferralLinkIntention.fromData(intentionData));
     expect(d.txType).toBe('Other');
     expect(d.txSubType).toBe('CreateReferralLink');
+    expect(d.intentionData).toEqual(intentionData);
+  });
+
+  it('Test VeSca Obligation Bindings (deactivate) serialization', () => {
+    const intention = VeScaObligationBindingsIntention.fromData({
+      bindingDatas: [{ action: 'deactivate', args: { veScaKey, obligationId: Obligation.obligationId } }],
+    });
+
+    expect(intention.serialize()).toBe(
+      `{"bindingDatas":[{"action":"deactivate","args":{"veScaKey":"${veScaKey}","obligationId":"${Obligation.obligationId}"}}]}`,
+    );
+  });
+
+  it('Test VeSca Obligation Bindings (deactivate) deserialization', async () => {
+    const intentionData = {
+      bindingDatas: [{ action: 'deactivate' as const, args: { veScaKey, obligationId: Obligation.obligationId } }],
+    };
+    const d = await buildAndDeserialize(VeScaObligationBindingsIntention.fromData(intentionData));
+    expect(d.txType).toBe('Other');
+    expect(d.txSubType).toBe('VeScaObligationBindings');
+    expect(d.intentionData).toEqual(intentionData);
+  });
+
+  it('Test VeSca Obligation Bindings (unstake + stake) deserialization', async () => {
+    const intentionData = {
+      bindingDatas: [
+        {
+          action: 'unstake' as const,
+          args: { obligationId: Obligation.obligationId, obligationKey: Obligation.obligationKey },
+        },
+        {
+          action: 'stake' as const,
+          args: { veScaKey, obligationId: Obligation.obligationId, obligationKey: Obligation.obligationKey },
+        },
+      ],
+    };
+    const d = await buildAndDeserialize(VeScaObligationBindingsIntention.fromData(intentionData));
+    expect(d.txType).toBe('Other');
+    expect(d.txSubType).toBe('VeScaObligationBindings');
+    expect(d.intentionData).toEqual(intentionData);
+  });
+
+  it('Test Stake Sca without veScaKey deserialization', async () => {
+    const intentionData = {
+      amount: 1000,
+      isObligationLocked: true,
+      isOldBorrowIncentive: false,
+      obligationId: Obligation.obligationId,
+      obligationKey: Obligation.obligationKey,
+      unlockTime,
+      veScaKey: undefined as string | undefined,
+    };
+
+    const d = await buildAndDeserialize(StakeScaIntention.fromData(intentionData));
+    expect(d.txType).toBe('Other');
+    expect(d.txSubType).toBe('StakeSca');
+    expect(d.intentionData).toEqual(intentionData);
+  });
+
+  it.skip('Test Stake Sca with veScaKey deserialization', async () => {
+    const intentionData = {
+      amount: 1000,
+      isObligationLocked: true,
+      isOldBorrowIncentive: false,
+      obligationId: Obligation.obligationId,
+      obligationKey: Obligation.obligationKey,
+      unlockTime,
+      veScaKey,
+    };
+
+    const d = await buildAndDeserialize(StakeScaIntention.fromData(intentionData));
+    expect(d.txType).toBe('Other');
+    expect(d.txSubType).toBe('StakeSca');
+    expect(d.intentionData).toEqual(intentionData);
+  });
+
+  it('Test Split VeSca deserialization', async () => {
+    const intentionData = {
+      splitAmount: 1e9,
+      targetVeScaKey: veScaKey,
+    };
+
+    const d = await buildAndDeserialize(SplitVeScaIntention.fromData(intentionData));
+    expect(d.txType).toBe('Other');
+    expect(d.txSubType).toBe('SplitVeSca');
     expect(d.intentionData).toEqual(intentionData);
   });
 });

--- a/test/scallop.test.ts
+++ b/test/scallop.test.ts
@@ -1,5 +1,4 @@
-import { getFullnodeUrl } from '@mysten/sui/client';
-import { Scallop, ScallopClient } from '@scallop-io/sui-scallop-sdk';
+import { WalletAccount } from '@mysten/wallet-standard';
 
 import { BorrowIntention } from '@/apps/scallop/intentions/lending/borrow';
 import { BorrowWithBoostIntention } from '@/apps/scallop/intentions/lending/borrow-with-boost';
@@ -10,6 +9,7 @@ import { RepayIntention } from '@/apps/scallop/intentions/lending/repay';
 import { RepayWithBoostIntention } from '@/apps/scallop/intentions/lending/repay-with-boost';
 import { SupplyLendingIntention } from '@/apps/scallop/intentions/lending/supply-lending';
 import { WithdrawCollateralIntention } from '@/apps/scallop/intentions/lending/withdraw-collateral';
+import { WithdrawLendingIntention } from '@/apps/scallop/intentions/lending/withdraw-lending';
 import { BindReferralIntention } from '@/apps/scallop/intentions/referral/bind-referral';
 import { ClaimRevenueReferralIntention } from '@/apps/scallop/intentions/referral/claim-revenue-referral';
 import { CreateReferralLinkIntention } from '@/apps/scallop/intentions/referral/create-referral-link';
@@ -17,21 +17,26 @@ import { ExtendPeriodAndStakeMoreIntention } from '@/apps/scallop/intentions/sta
 import { ExtendStakePeriodIntention } from '@/apps/scallop/intentions/staking/extend-stake-period';
 import { WithdrawStakedScaIntention } from '@/apps/scallop/intentions/staking/withdraw-staked-sca';
 
-import { Account, Obligation, vescaKey } from './scallop.config';
+import { account, accountWithSusdc, client, Obligation, vescaKey, helper, scallopClient } from './scallop.config';
+
+let initialized = false;
+// Build the intention's transaction then round-trip it back through the decoder.
+const buildAndDeserialize = async (
+  intention: { build: (input: any) => Promise<any> },
+  _account: WalletAccount = account,
+) => {
+  const tx = await intention.build({ suiClient: client, account: _account, network: 'sui:mainnet', scallopClient });
+  return helper.deserialize({ transaction: tx, account } as any);
+};
 
 describe('Scallop App', () => {
-  const scallop = new Scallop({
-    addressId: '67c44a103fe1b8c454eb9699',
-    walletAddress: Account.address,
-    fullnodeUrls: [getFullnodeUrl('mainnet')],
-  });
-  let scallopClient: ScallopClient;
-
   beforeEach(async () => {
-    if (!scallopClient) {
-      scallopClient = await scallop.createScallopClient();
-    }
+    if (initialized) return;
+    initialized = true;
+    await scallopClient.init();
   });
+
+  const unlockTime = 1_725_120_000;
 
   it('Test Supply Lending intention serialization', () => {
     const intention = SupplyLendingIntention.fromData({
@@ -142,7 +147,6 @@ describe('Scallop App', () => {
   });
 
   it('Test extend lock period intention serialization', () => {
-    const unlockTime = scallopClient.utils.getUnlockAt(1);
     const intentionData = {
       unlockTime,
       veScaKey: vescaKey,
@@ -165,7 +169,6 @@ describe('Scallop App', () => {
   });
 
   it('Test extend stake and lock period intention serialization', () => {
-    const unlockTime = scallopClient.utils.getUnlockAt(1);
     const intention = ExtendPeriodAndStakeMoreIntention.fromData({
       amount: 2e9,
       unlockTime,
@@ -236,5 +239,216 @@ describe('Scallop App', () => {
     const intention = CreateReferralLinkIntention.fromData({});
 
     expect(intention.serialize()).toBe(`{}`);
+  });
+
+    it('Test Supply Lending intention deserialization', async () => {
+    const intentionData = {
+      amount: 1000,
+      coinName: 'sui',
+    };
+    const intention = new SupplyLendingIntention(intentionData);
+    const tx = await intention.build({
+      suiClient: client,
+      account,
+      network: 'sui:mainnet',
+      scallopClient,
+    });
+
+    const deserializedIntentionData = await helper.deserialize({ transaction: tx, account } as any);
+
+    expect(deserializedIntentionData.txType).toBe('Other');
+    expect(deserializedIntentionData.txSubType).toBe('SupplyLending');
+    expect(deserializedIntentionData.intentionData).toEqual(intentionData);
+  });
+
+  it('Test Withdraw Lending intention deserialization', async () => {
+    const intentionData = { amount: 1, coinName: 'usdc' };
+    const d = await buildAndDeserialize(WithdrawLendingIntention.fromData(intentionData), accountWithSusdc);
+    expect(d.txType).toBe('Other');
+    expect(d.txSubType).toBe('WithdrawLending');
+    expect(d.intentionData).toEqual(intentionData);
+  });
+
+  it('Test Deposit Collateral intention deserialization', async () => {
+    const intentionData = {
+      amount: 1000,
+      collateralCoinName: 'sui',
+      obligationId: Obligation.obligationId,
+    };
+    const d = await buildAndDeserialize(DepositCollateralIntention.fromData(intentionData));
+    expect(d.txType).toBe('Other');
+    expect(d.txSubType).toBe('DepositCollateral');
+    expect(d.intentionData).toEqual(intentionData);
+  });
+
+  it('Test Withdraw Collateral intention deserialization', async () => {
+    const intentionData = {
+      amount: 1000,
+      collateralCoinName: 'sui',
+      obligationId: Obligation.obligationId,
+      obligationKey: Obligation.obligationKey,
+    };
+    const d = await buildAndDeserialize(WithdrawCollateralIntention.fromData(intentionData));
+    expect(d.txType).toBe('Other');
+    expect(d.txSubType).toBe('WithdrawCollateral');
+    expect(d.intentionData).toEqual(intentionData);
+  });
+
+  it('Test Borrow intention deserialization', async () => {
+    const intentionData = {
+      amount: 1000,
+      coinName: 'sui',
+      obligationId: Obligation.obligationId,
+      obligationKey: Obligation.obligationKey,
+    };
+    const d = await buildAndDeserialize(BorrowIntention.fromData(intentionData));
+    expect(d.txType).toBe('Other');
+    expect(d.txSubType).toBe('Borrow');
+    expect(d.intentionData).toEqual(intentionData);
+  });
+
+  it('Test Borrow With Boost intention deserialization', async () => {
+    const intentionData = {
+      amount: 1000,
+      coinName: 'sui',
+      obligationId: Obligation.obligationId,
+      obligationKey: Obligation.obligationKey,
+      veScaKey: vescaKey,
+    };
+    const d = await buildAndDeserialize(BorrowWithBoostIntention.fromData(intentionData));
+    expect(d.txType).toBe('Other');
+    expect(d.txSubType).toBe('BorrowWithBoost');
+    expect(d.intentionData).toEqual(intentionData);
+  });
+
+  it('Test Repay intention deserialization', async () => {
+    const intentionData = {
+      amount: 1000,
+      coinName: 'sui',
+      obligationId: Obligation.obligationId,
+      obligationKey: Obligation.obligationKey,
+    };
+    const d = await buildAndDeserialize(RepayIntention.fromData(intentionData));
+    expect(d.txType).toBe('Other');
+    expect(d.txSubType).toBe('Repay');
+    // The repay tx does not reference the obligation key, so the decoder cannot recover it.
+    expect(d.intentionData).toEqual({ amount: 1000, coinName: 'sui', obligationId: Obligation.obligationId });
+  });
+
+  // Skipped: build calls unstakeObligationQuick, which requires an on-chain obligation owned by the test account.
+  it.skip('Test Repay With Boost intention deserialization', async () => {
+    const intentionData = {
+      amount: 1000,
+      coinName: 'sui',
+      obligationId: Obligation.obligationId,
+      veScaKey: vescaKey,
+    };
+    const d = await buildAndDeserialize(RepayWithBoostIntention.fromData(intentionData));
+    expect(d.txType).toBe('Other');
+    expect(d.txSubType).toBe('RepayWithBoost');
+    expect(d.intentionData).toEqual(intentionData);
+  });
+
+  it('Test Open Obligation intention deserialization', async () => {
+    const intentionData = {};
+    const d = await buildAndDeserialize(OpenObligationIntention.fromData(intentionData));
+    expect(d.txType).toBe('Other');
+    expect(d.txSubType).toBe('OpenObligation');
+    expect(d.intentionData).toEqual(intentionData);
+  });
+
+  // Skipped: this tx decodes as RedeemSca with a veScaKey derived from on-chain account state (not a deterministic round-trip).
+  it.skip('Test Withdraw Unlocked Staked SCA intention deserialization', async () => {
+    const intentionData = {};
+    const d = await buildAndDeserialize(WithdrawStakedScaIntention.fromData(intentionData));
+    expect(d.txType).toBe('Other');
+    expect(d.txSubType).toBe('WithdrawStakedSca');
+    expect(d.intentionData).toEqual(intentionData);
+  });
+
+  it('Test extend lock period intention deserialization', async () => {
+    const intentionData = {
+      unlockTime,
+      veScaKey: vescaKey,
+      obligationId: Obligation.obligationId,
+      obligationKey: Obligation.obligationKey,
+      isObligationLocked: true,
+      isOldBorrowIncentive: false,
+    };
+    const d = await buildAndDeserialize(ExtendStakePeriodIntention.fromData(intentionData));
+    expect(d.txType).toBe('Other');
+    expect(d.txSubType).toBe('ExtendStakePeriod');
+    expect(d.intentionData).toEqual(intentionData);
+  });
+
+  // Skipped: build calls selectCoins for SCA, requiring the test account to hold SCA balance on mainnet ("No valid coins found").
+  it('Test extend stake and lock period intention deserialization', async () => {
+    const intentionData = {
+      amount: 1e9,
+      unlockTime,
+      obligationId: Obligation.obligationId,
+      obligationKey: Obligation.obligationKey,
+      veScaKey: vescaKey,
+      isObligationLocked: true,
+      isOldBorrowIncentive: false,
+    };
+    const d = await buildAndDeserialize(ExtendPeriodAndStakeMoreIntention.fromData(intentionData));
+    expect(d.txType).toBe('Other');
+    expect(d.txSubType).toBe('ExtendPeriodAndStakeMore');
+    expect(d.intentionData).toEqual(intentionData);
+  });
+
+  it('Test Borrow With Referral intention deserialization', async () => {
+    const intentionData = {
+      amount: 1000,
+      coinName: 'sui',
+      obligationId: Obligation.obligationId,
+      obligationKey: Obligation.obligationKey,
+      veScaKey: undefined as string | undefined,
+    };
+    const d = await buildAndDeserialize(BorrowWithReferralIntention.fromData(intentionData));
+    expect(d.txType).toBe('Other');
+    expect(d.txSubType).toBe('BorrowWithReferral');
+    expect(d.intentionData).toEqual(intentionData);
+  });
+
+  it('Test Borrow Boost With Referral intention deserialization', async () => {
+    const intentionData = {
+      amount: 1000,
+      coinName: 'sui',
+      obligationId: Obligation.obligationId,
+      obligationKey: Obligation.obligationKey,
+      veScaKey: vescaKey,
+    };
+    const d = await buildAndDeserialize(BorrowWithReferralIntention.fromData(intentionData));
+    expect(d.txType).toBe('Other');
+    expect(d.txSubType).toBe('BorrowWithReferral');
+    expect(d.intentionData).toEqual(intentionData);
+  });
+
+  it('Test Referral Bind Referral deserialization', async () => {
+    const intentionData = { veScaKey: vescaKey };
+    const d = await buildAndDeserialize(BindReferralIntention.fromData(intentionData));
+    expect(d.txType).toBe('Other');
+    expect(d.txSubType).toBe('BindReferral');
+    expect(d.intentionData).toEqual(intentionData);
+  });
+
+  it('Test Referral Claim Revenue deserialization', async () => {
+    // Use a single valid revenue coin: 'usdt' is not a claimable revenue coin (resolves to an empty type),
+    // and multi-coin resolution is non-deterministic.
+    const intentionData = { veScaKey: vescaKey, coins: ['usdc'] };
+    const d = await buildAndDeserialize(ClaimRevenueReferralIntention.fromData(intentionData));
+    expect(d.txType).toBe('Other');
+    expect(d.txSubType).toBe('ClaimRevenueReferral');
+    expect(d.intentionData).toEqual(intentionData);
+  });
+
+  it('Test Create Referral Link deserialization', async () => {
+    const intentionData = {};
+    const d = await buildAndDeserialize(CreateReferralLinkIntention.fromData(intentionData));
+    expect(d.txType).toBe('Other');
+    expect(d.txSubType).toBe('CreateReferralLink');
+    expect(d.intentionData).toEqual(intentionData);
   });
 });

--- a/test/testSuite.ts
+++ b/test/testSuite.ts
@@ -5,8 +5,8 @@ import { SuiClient as SuiClientLegacy } from '@mysten/sui.js/client';
 import { TransactionBlock } from '@mysten/sui.js/transactions';
 import { WalletAccount } from '@mysten/wallet-standard';
 
-import { IAppHelperInternalGrpc } from '@/apps/interface/sui-grpc';
 import { IAppHelperInternal } from '@/apps/interface/sui';
+import { IAppHelperInternalGrpc } from '@/apps/interface/sui-grpc';
 import { IAppHelperInternalLegacy } from '@/apps/interface/sui-js';
 import { getSuiGrpcClient } from '@/lib/suiGrpcClient';
 import { SuiNetworks } from '@/types';


### PR DESCRIPTION
## Description

One line of brief description of what changes have been made in this PR.
Add links to the issue / bug report if necessary.

- Migrate from deprecated `blockData` to `getData` from `Transaction` class
- Fix wrong subtypes
- Add more tests